### PR TITLE
[WIP] Work towards improving the duplicate blocks issue

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -30,6 +30,8 @@ import (
 
 var log = logging.Logger("bitswap")
 
+var _ exchange.SessionExchange = (*Bitswap)(nil)
+
 const (
 	// maxProvidersPerRequest specifies the maximum number of providers desired
 	// from the network. This value is specified because the network streams

--- a/dup_blocks_test.go
+++ b/dup_blocks_test.go
@@ -16,7 +16,7 @@ import (
 	mockrouting "github.com/ipfs/go-ipfs-routing/mock"
 )
 
-type fetchFunc func(t *testing.T, bs *Bitswap, ks []*cid.Cid)
+type fetchFunc func(t *testing.T, bs *Bitswap, ks []cid.Cid)
 
 type distFunc func(t *testing.T, provs []Instance, blocks []blocks.Block)
 
@@ -94,7 +94,7 @@ func subtestDistributeAndFetch(t *testing.T, numnodes, numblks int, df distFunc,
 
 	df(t, instances[:numnodes-1], blocks)
 
-	var ks []*cid.Cid
+	var ks []cid.Cid
 	for _, blk := range blocks {
 		ks = append(ks, blk.Cid())
 	}
@@ -192,7 +192,7 @@ func onePeerPerBlock(t *testing.T, provs []Instance, blks []blocks.Block) {
 	}
 }
 
-func oneAtATime(t *testing.T, bs *Bitswap, ks []*cid.Cid) {
+func oneAtATime(t *testing.T, bs *Bitswap, ks []cid.Cid) {
 	ses := bs.NewSession(context.Background())
 	for _, c := range ks {
 		_, err := ses.GetBlock(context.Background(), c)
@@ -204,7 +204,7 @@ func oneAtATime(t *testing.T, bs *Bitswap, ks []*cid.Cid) {
 }
 
 // fetch data in batches, 10 at a time
-func batchFetchBy10(t *testing.T, bs *Bitswap, ks []*cid.Cid) {
+func batchFetchBy10(t *testing.T, bs *Bitswap, ks []cid.Cid) {
 	ses := bs.NewSession(context.Background())
 	for i := 0; i < len(ks); i += 10 {
 		out, err := ses.GetBlocks(context.Background(), ks[i:i+10])
@@ -217,13 +217,13 @@ func batchFetchBy10(t *testing.T, bs *Bitswap, ks []*cid.Cid) {
 }
 
 // fetch each block at the same time concurrently
-func fetchAllConcurrent(t *testing.T, bs *Bitswap, ks []*cid.Cid) {
+func fetchAllConcurrent(t *testing.T, bs *Bitswap, ks []cid.Cid) {
 	ses := bs.NewSession(context.Background())
 
 	var wg sync.WaitGroup
 	for _, c := range ks {
 		wg.Add(1)
-		go func(c *cid.Cid) {
+		go func(c cid.Cid) {
 			defer wg.Done()
 			_, err := ses.GetBlock(context.Background(), c)
 			if err != nil {
@@ -234,7 +234,7 @@ func fetchAllConcurrent(t *testing.T, bs *Bitswap, ks []*cid.Cid) {
 	wg.Wait()
 }
 
-func batchFetchAll(t *testing.T, bs *Bitswap, ks []*cid.Cid) {
+func batchFetchAll(t *testing.T, bs *Bitswap, ks []cid.Cid) {
 	ses := bs.NewSession(context.Background())
 	out, err := ses.GetBlocks(context.Background(), ks)
 	if err != nil {
@@ -245,7 +245,7 @@ func batchFetchAll(t *testing.T, bs *Bitswap, ks []*cid.Cid) {
 }
 
 // simulates the fetch pattern of trying to sync a unixfs file graph as fast as possible
-func unixfsFileFetch(t *testing.T, bs *Bitswap, ks []*cid.Cid) {
+func unixfsFileFetch(t *testing.T, bs *Bitswap, ks []cid.Cid) {
 	ses := bs.NewSession(context.Background())
 	_, err := ses.GetBlock(context.Background(), ks[0])
 	if err != nil {

--- a/dup_blocks_test.go
+++ b/dup_blocks_test.go
@@ -2,7 +2,6 @@ package bitswap
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	mockrouting "github.com/ipfs/go-ipfs-routing/mock"
 )
 
+// in this test, each of the data-having peers has all the data
 func TestDuplicateBlocksIssues(t *testing.T) {
 	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(10*time.Millisecond))
 	sg := NewTestSessionGenerator(net)
@@ -35,8 +35,7 @@ func TestDuplicateBlocksIssues(t *testing.T) {
 	}
 
 	ses := steve.Exchange.NewSession(context.Background())
-	for i, blk := range blocks {
-		fmt.Println("fetch block: ", i)
+	for _, blk := range blocks {
 		ses.GetBlock(context.Background(), blk.Cid())
 	}
 
@@ -45,5 +44,91 @@ func TestDuplicateBlocksIssues(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fmt.Println("duplicate blocks: ", st.DupBlksReceived)
+	if st.DupBlksReceived != 0 {
+		t.Fatalf("got %d duplicate blocks!", st.DupBlksReceived)
+	}
+}
+
+// in this test, each of the 'other peers' has 3/4 of the data. and a 1/2
+// overlap in blocks with the other data-having peer
+// interestingly, because of the way sessions currently work, this results in zero wasted data
+func TestDupBlocksOverlap1(t *testing.T) {
+	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(10*time.Millisecond))
+	sg := NewTestSessionGenerator(net)
+	defer sg.Close()
+
+	bg := blocksutil.NewBlockGenerator()
+
+	instances := sg.Instances(3)
+	blocks := bg.Blocks(100)
+
+	bill := instances[0]
+	jeff := instances[1]
+	steve := instances[2]
+
+	if err := bill.Blockstore().PutMany(blocks[:75]); err != nil {
+		t.Fatal(err)
+	}
+	if err := jeff.Blockstore().PutMany(blocks[25:]); err != nil {
+		t.Fatal(err)
+	}
+
+	ses := steve.Exchange.NewSession(context.Background())
+	for _, blk := range blocks {
+		ses.GetBlock(context.Background(), blk.Cid())
+	}
+
+	st, err := steve.Exchange.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if st.DupBlksReceived != 0 {
+		t.Fatal("got duplicate blocks!")
+	}
+}
+
+// in this test, each of the 'other peers' some of the data, with an overlap
+// different from the previous test, both peers have the 'first' block, which triggers sessions
+// into behaving poorly
+func TestDupBlocksOverlap2(t *testing.T) {
+	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(10*time.Millisecond))
+	sg := NewTestSessionGenerator(net)
+	defer sg.Close()
+
+	bg := blocksutil.NewBlockGenerator()
+
+	instances := sg.Instances(3)
+	blocks := bg.Blocks(100)
+
+	bill := instances[0]
+	jeff := instances[1]
+	steve := instances[2]
+
+	bill.Blockstore().Put(blocks[0])
+	jeff.Blockstore().Put(blocks[0])
+	for i, blk := range blocks {
+		if i%3 == 0 {
+			bill.Blockstore().Put(blk)
+			jeff.Blockstore().Put(blk)
+		} else if i%2 == 1 {
+			bill.Blockstore().Put(blk)
+		} else {
+			jeff.Blockstore().Put(blk)
+		}
+	}
+
+	ses := steve.Exchange.NewSession(context.Background())
+	for _, blk := range blocks {
+		ses.GetBlock(context.Background(), blk.Cid())
+	}
+
+	st, err := steve.Exchange.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if st.DupBlksReceived != 0 {
+		t.Fatalf("got %d duplicate blocks!", st.DupBlksReceived)
+	}
 }

--- a/dup_blocks_test.go
+++ b/dup_blocks_test.go
@@ -106,6 +106,8 @@ func subtestDistributeAndFetch(t *testing.T, numnodes, numblks int, df distFunc,
 		t.Fatal(err)
 	}
 
+	nst := fetcher.Exchange.network.Stats()
+	t.Logf("send/recv: %d / %d", nst.MessagesSent, nst.MessagesRecvd)
 	if st.DupBlksReceived != 0 {
 		t.Fatalf("got %d duplicate blocks!", st.DupBlksReceived)
 	}

--- a/dup_blocks_test.go
+++ b/dup_blocks_test.go
@@ -87,6 +87,9 @@ func TestDups2Nodes(t *testing.T) {
 	t.Run("10Nodes-OnePeerPerBlock-UnixfsFetch", func(t *testing.T) {
 		subtestDistributeAndFetch(t, 10, 100, onePeerPerBlock, unixfsFileFetch)
 	})
+	t.Run("200Nodes-AllToAll-BigBatch", func(t *testing.T) {
+		subtestDistributeAndFetch(t, 200, 20, allToAll, batchFetchAll)
+	})
 
 	out, _ := json.MarshalIndent(benchmarkLog, "", "  ")
 	ioutil.WriteFile("benchmark.json", out, 0666)
@@ -130,7 +133,7 @@ func subtestDistributeAndFetch(t *testing.T, numnodes, numblks int, df distFunc,
 	benchmarkLog = append(benchmarkLog, stats)
 	t.Logf("send/recv: %d / %d", nst.MessagesSent, nst.MessagesRecvd)
 	if st.DupBlksReceived != 0 {
-		//t.Fatalf("got %d duplicate blocks!", st.DupBlksReceived)
+		t.Fatalf("got %d duplicate blocks!", st.DupBlksReceived)
 	}
 }
 
@@ -214,7 +217,7 @@ func onePeerPerBlock(t *testing.T, provs []Instance, blks []blocks.Block) {
 }
 
 func oneAtATime(t *testing.T, bs *Bitswap, ks []cid.Cid) {
-	ses := bs.NewSession(context.Background())
+	ses := bs.NewSession(context.Background()).(*Session)
 	for _, c := range ks {
 		_, err := ses.GetBlock(context.Background(), c)
 		if err != nil {

--- a/dup_blocks_test.go
+++ b/dup_blocks_test.go
@@ -2,11 +2,13 @@ package bitswap
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	tn "github.com/ipfs/go-bitswap/testnet"
 
+	cid "github.com/ipfs/go-cid"
 	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
 	delay "github.com/ipfs/go-ipfs-delay"
 	mockrouting "github.com/ipfs/go-ipfs-routing/mock"
@@ -121,6 +123,167 @@ func TestDupBlocksOverlap2(t *testing.T) {
 	ses := steve.Exchange.NewSession(context.Background())
 	for _, blk := range blocks {
 		ses.GetBlock(context.Background(), blk.Cid())
+	}
+
+	st, err := steve.Exchange.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if st.DupBlksReceived != 0 {
+		t.Fatalf("got %d duplicate blocks!", st.DupBlksReceived)
+	}
+}
+
+// in this test, each of the 'other peers' some of the data, with an overlap
+// The data is fetched in bulk, with a single 'getBlocks' call
+func TestDupBlocksOverlapBatch1(t *testing.T) {
+	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(10*time.Millisecond))
+	sg := NewTestSessionGenerator(net)
+	defer sg.Close()
+
+	bg := blocksutil.NewBlockGenerator()
+
+	instances := sg.Instances(3)
+	blocks := bg.Blocks(100)
+
+	bill := instances[0]
+	jeff := instances[1]
+	steve := instances[2]
+
+	bill.Blockstore().Put(blocks[0])
+	jeff.Blockstore().Put(blocks[0])
+	for i, blk := range blocks {
+		if i%3 == 0 {
+			bill.Blockstore().Put(blk)
+			jeff.Blockstore().Put(blk)
+		} else if i%2 == 1 {
+			bill.Blockstore().Put(blk)
+		} else {
+			jeff.Blockstore().Put(blk)
+		}
+	}
+
+	ses := steve.Exchange.NewSession(context.Background())
+
+	var ks []*cid.Cid
+	for _, blk := range blocks {
+		ks = append(ks, blk.Cid())
+	}
+	out, err := ses.GetBlocks(context.Background(), ks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range out {
+	}
+
+	st, err := steve.Exchange.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if st.DupBlksReceived != 0 {
+		t.Fatalf("got %d duplicate blocks!", st.DupBlksReceived)
+	}
+}
+
+// in this test, each of the 'other peers' some of the data, with an overlap
+// The data is fetched in bulk, with N concurrent calls to 'getBlock'
+func TestDupBlocksOverlapBatch2(t *testing.T) {
+	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(10*time.Millisecond))
+	sg := NewTestSessionGenerator(net)
+	defer sg.Close()
+
+	bg := blocksutil.NewBlockGenerator()
+
+	instances := sg.Instances(3)
+	blocks := bg.Blocks(100)
+
+	bill := instances[0]
+	jeff := instances[1]
+	steve := instances[2]
+
+	bill.Blockstore().Put(blocks[0])
+	jeff.Blockstore().Put(blocks[0])
+	for i, blk := range blocks {
+		if i%3 == 0 {
+			bill.Blockstore().Put(blk)
+			jeff.Blockstore().Put(blk)
+		} else if i%2 == 1 {
+			bill.Blockstore().Put(blk)
+		} else {
+			jeff.Blockstore().Put(blk)
+		}
+	}
+
+	ses := steve.Exchange.NewSession(context.Background())
+
+	var wg sync.WaitGroup
+	for _, blk := range blocks {
+		wg.Add(1)
+		go func(c *cid.Cid) {
+			defer wg.Done()
+			_, err := ses.GetBlock(context.Background(), c)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}(blk.Cid())
+	}
+	wg.Wait()
+
+	st, err := steve.Exchange.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if st.DupBlksReceived != 0 {
+		t.Fatalf("got %d duplicate blocks!", st.DupBlksReceived)
+	}
+}
+
+// in this test, each of the 'other peers' some of the data, with an overlap
+// The data is fetched in bulk, fetching ten blocks at a time with 'getBlocks'
+func TestDupBlocksOverlapBatch3(t *testing.T) {
+	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(10*time.Millisecond))
+	sg := NewTestSessionGenerator(net)
+	defer sg.Close()
+
+	bg := blocksutil.NewBlockGenerator()
+
+	instances := sg.Instances(3)
+	blocks := bg.Blocks(100)
+
+	bill := instances[0]
+	jeff := instances[1]
+	steve := instances[2]
+
+	bill.Blockstore().Put(blocks[0])
+	jeff.Blockstore().Put(blocks[0])
+	for i, blk := range blocks {
+		if i%3 == 0 {
+			bill.Blockstore().Put(blk)
+			jeff.Blockstore().Put(blk)
+		} else if i%2 == 1 {
+			bill.Blockstore().Put(blk)
+		} else {
+			jeff.Blockstore().Put(blk)
+		}
+	}
+
+	ses := steve.Exchange.NewSession(context.Background())
+
+	var ks []*cid.Cid
+	for _, blk := range blocks {
+		ks = append(ks, blk.Cid())
+	}
+
+	for i := 0; i < len(ks); i += 10 {
+		out, err := ses.GetBlocks(context.Background(), ks[i:i+10])
+		if err != nil {
+			t.Fatal(err)
+		}
+		for range out {
+		}
 	}
 
 	st, err := steve.Exchange.Stat()

--- a/dup_blocks_test.go
+++ b/dup_blocks_test.go
@@ -1,0 +1,49 @@
+package bitswap
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	tn "github.com/ipfs/go-bitswap/testnet"
+
+	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
+	delay "github.com/ipfs/go-ipfs-delay"
+	mockrouting "github.com/ipfs/go-ipfs-routing/mock"
+)
+
+func TestDuplicateBlocksIssues(t *testing.T) {
+	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(10*time.Millisecond))
+	sg := NewTestSessionGenerator(net)
+	defer sg.Close()
+
+	bg := blocksutil.NewBlockGenerator()
+
+	instances := sg.Instances(3)
+	blocks := bg.Blocks(100)
+
+	bill := instances[0]
+	jeff := instances[1]
+	steve := instances[2]
+
+	if err := bill.Blockstore().PutMany(blocks); err != nil {
+		t.Fatal(err)
+	}
+	if err := jeff.Blockstore().PutMany(blocks); err != nil {
+		t.Fatal(err)
+	}
+
+	ses := steve.Exchange.NewSession(context.Background())
+	for i, blk := range blocks {
+		fmt.Println("fetch block: ", i)
+		ses.GetBlock(context.Background(), blk.Cid())
+	}
+
+	st, err := steve.Exchange.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println("duplicate blocks: ", st.DupBlksReceived)
+}

--- a/network/interface.go
+++ b/network/interface.go
@@ -38,6 +38,8 @@ type BitSwapNetwork interface {
 
 	ConnectionManager() ifconnmgr.ConnManager
 
+	Stats() NetworkStats
+
 	Routing
 }
 
@@ -67,4 +69,12 @@ type Routing interface {
 
 	// Provide provides the key to the network
 	Provide(context.Context, cid.Cid) error
+}
+
+// NetworkStats is a container for statistics about the bitswap network
+// the numbers inside are specific to bitswap, and not any other protocols
+// using the same underlying network.
+type NetworkStats struct {
+	MessagesSent  uint64
+	MessagesRecvd uint64
 }

--- a/network/ipfs_impl.go
+++ b/network/ipfs_impl.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync/atomic"
 	"time"
 
 	bsmsg "github.com/ipfs/go-bitswap/message"
@@ -48,6 +49,8 @@ type impl struct {
 
 	// inbound messages from the network are forwarded to the receiver
 	receiver Receiver
+
+	stats NetworkStats
 }
 
 type streamMessageSender struct {
@@ -130,6 +133,8 @@ func (bsnet *impl) SendMessage(
 		s.Reset()
 		return err
 	}
+	atomic.AddUint64(&bsnet.stats.MessagesSent, 1)
+
 	// TODO(https://github.com/libp2p/go-libp2p-net/issues/28): Avoid this goroutine.
 	go inet.AwaitEOF(s)
 	return s.Close()
@@ -210,11 +215,19 @@ func (bsnet *impl) handleNewStream(s inet.Stream) {
 		ctx := context.Background()
 		log.Debugf("bitswap net handleNewStream from %s", s.Conn().RemotePeer())
 		bsnet.receiver.ReceiveMessage(ctx, p, received)
+		atomic.AddUint64(&bsnet.stats.MessagesRecvd, 1)
 	}
 }
 
 func (bsnet *impl) ConnectionManager() ifconnmgr.ConnManager {
 	return bsnet.host.ConnManager()
+}
+
+func (bsnet *impl) Stats() NetworkStats {
+	return NetworkStats{
+		MessagesRecvd: atomic.LoadUint64(&bsnet.stats.MessagesRecvd),
+		MessagesSent:  atomic.LoadUint64(&bsnet.stats.MessagesSent),
+	}
 }
 
 type netNotifiee impl

--- a/package.json
+++ b/package.json
@@ -87,9 +87,9 @@
     },
     {
       "author": "hsanjuan",
-      "hash": "QmR1nncPsZR14A4hWr39mq8Lm7BGgS68bHVT9nop8NpWEM",
+      "hash": "QmUdh9184Bozfinyn5YDhgPRg33E3KR3btfZXcVoFgTxD4",
       "name": "go-ipfs-exchange-interface",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     {
       "author": "whyrusleeping",

--- a/session.go
+++ b/session.go
@@ -11,6 +11,7 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
+	exchange "github.com/ipfs/go-ipfs-exchange-interface"
 	logging "github.com/ipfs/go-log"
 	loggables "github.com/libp2p/go-libp2p-loggables"
 	peer "github.com/libp2p/go-libp2p-peer"
@@ -70,7 +71,7 @@ type Session struct {
 
 // NewSession creates a new bitswap session whose lifetime is bounded by the
 // given context
-func (bs *Bitswap) NewSession(ctx context.Context) *Session {
+func (bs *Bitswap) NewSession(ctx context.Context) exchange.Fetcher {
 	s := &Session{
 		activePeers:    make(map[peer.ID]struct{}),
 		liveWants:      make(map[cid.Cid]time.Time),

--- a/session_test.go
+++ b/session_test.go
@@ -132,7 +132,7 @@ func TestSessionSplitFetch(t *testing.T) {
 		cids = append(cids, blk.Cid())
 	}
 
-	ses := inst[10].Exchange.NewSession(ctx)
+	ses := inst[10].Exchange.NewSession(ctx).(*Session)
 	ses.baseTickDelay = time.Millisecond * 10
 
 	for i := 0; i < 10; i++ {

--- a/stat.go
+++ b/stat.go
@@ -7,15 +7,16 @@ import (
 )
 
 type Stat struct {
-	ProvideBufLen   int
-	Wantlist        []cid.Cid
-	Peers           []string
-	BlocksReceived  uint64
-	DataReceived    uint64
-	BlocksSent      uint64
-	DataSent        uint64
-	DupBlksReceived uint64
-	DupDataReceived uint64
+	ProvideBufLen    int
+	Wantlist         []cid.Cid
+	Peers            []string
+	BlocksReceived   uint64
+	DataReceived     uint64
+	BlocksSent       uint64
+	DataSent         uint64
+	DupBlksReceived  uint64
+	DupDataReceived  uint64
+	MessagesReceived uint64
 }
 
 func (bs *Bitswap) Stat() (*Stat, error) {
@@ -30,6 +31,7 @@ func (bs *Bitswap) Stat() (*Stat, error) {
 	st.BlocksSent = c.blocksSent
 	st.DataSent = c.dataSent
 	st.DataReceived = c.dataRecvd
+	st.MessagesReceived = c.messagesRecvd
 	bs.counterLk.Unlock()
 
 	peers := bs.engine.Peers()

--- a/testutils.go
+++ b/testutils.go
@@ -81,7 +81,7 @@ func (i *Instance) SetBlockstoreLatency(t time.Duration) time.Duration {
 	return i.blockstoreDelay.Set(t)
 }
 
-// session creates a test bitswap session.
+// session creates a test bitswap instance.
 //
 // NB: It's easy make mistakes by providing the same peer ID to two different
 // sessions. To safeguard, use the SessionGenerator to generate sessions. It's


### PR DESCRIPTION
Bitswap currently has a bad problem of getting duplicate blocks. That is, if we ask for X, and more than one of our peers has X, we will probably get X from each of those peers. Wasting bandwidth.

In this branch, we will attempt to fix the problem (or at least, improve it).

The first thing i've added here is a test that shows the problem. From there, we can try and get the duplication factor as low as possible.