### PR TITLE
gx: update go-libp2p-routing

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.1.1: QmUyaGN3WPr3CTLai7DBvMikagK45V4fUi8p8cNRaJQoU1
+1.1.2: QmenvDer6Lfv9Q8mDWS2hcYscvEv1RJgvXkPjZX3thLr6g

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     },
     {
       "author": "hsanjuan",
-      "hash": "QmSNe4MWVxZWk6UxxW2z2EKofFo4GdFzud1vfn1iVby3mj",
+      "hash": "QmPKLDMELt3Z1g4fHZoE8HEj3THpTnpynHUQDjW1gDMUdk",
       "name": "go-ipfs-routing",
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     {
       "author": "whyrusleeping",
@@ -175,9 +175,9 @@
       "version": "3.1.0"
     },
     {
-      "hash": "QmdKS5YtmuSWKuLLgbHG176mS3VX3AKiyVmaaiAfvgcuch",
+      "hash": "QmaM261ArNTmKMybV4LKy68JTZrf5CkCbRGDxsZwYHgqDS",
       "name": "go-libp2p-routing",
-      "version": "2.5.0"
+      "version": "2.6.1"
     },
     {
       "author": "jbenet",
@@ -191,6 +191,6 @@
   "license": "",
   "name": "go-bitswap",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.1.1"
+  "version": "1.1.2"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-kad-dht/pull/199
- https://github.com/ipfs/go-ipfs-routing/pull/14
- https://github.com/libp2p/go-libp2p-routing-helpers/pull/8
- https://github.com/libp2p/go-libp2p-pubsub-router/pull/10


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace