### PR TITLE
fix(Receiver): Ignore unwanted blocks

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -388,6 +388,7 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 
 	wg := sync.WaitGroup{}
 	for _, block := range iblocks {
+
 		wg.Add(1)
 		go func(b blocks.Block) { // TODO: this probably doesnt need to be a goroutine...
 			defer wg.Done()
@@ -395,6 +396,11 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 			bs.updateReceiveCounters(b)
 
 			log.Debugf("got block %s from %s", b, p)
+
+			// skip received blocks that are not in the wantlist
+			if _, contains := bs.wm.wl.Contains(b.Cid()); !contains {
+				return
+			}
 
 			if err := bs.receiveBlockFrom(b, p); err != nil {
 				log.Warningf("ReceiveMessage recvBlockFrom error: %s", err)


### PR DESCRIPTION
# Goals

If Bitswap receives a block that isn't in it's wantlist, is should ignore it, and not add it to the block store

# Implementation

Blocks get received in bitswap one of two ways. They're either added by the user (HasBlock) -- and in this case it seems like they should always get added to the blockstore. Or, they come in through the network -- through the ReceiveMessage function. It seems to me, and it's possible I'm missing something, this is the place to ignore an unwanted block. This perhaps naive implementation simply checks blocks received from the network against the global wantlist and ignores them if they aren't in the wantlist.

# For Discussion

There are interesting questions about what exactly we want to do and not do with an unwanted block. This approach counts the block in statistics but doesn't provide it, add it to the block store, send it to sessions, or anything else.

The reason for counting in statistics is information was transferred and received, and duplicate blocks likely have been removed from the wantlist but were requested at some point, making them worth recording as duplicate blocks.

But it might merit further examination to figure out if this is the exact right set of things to "not do" if we get a block that's not in the want list.

fix #21 fix #22