### PR TITLE
feat(Benchmarks): Add real world dup blocks test

### DIFF
--- a/testnet/internet_latency_delay_generator.go
+++ b/testnet/internet_latency_delay_generator.go
@@ -1,0 +1,63 @@
+package bitswap
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/ipfs/go-ipfs-delay"
+)
+
+var sharedRNG = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// InternetLatencyDelayGenerator generates three clusters of delays,
+// typical of the type of peers you would encounter on the interenet
+// Given a base delay time T, the wait time generated will be either:
+// 1. A normalized distribution around the base time
+// 2. A normalized distribution around the base time plus a "medium" delay
+// 3. A normalized distribution around the base time plus a "large" delay
+// The size of the medium & large delays are determined when the generator
+// is constructed, as well as the relative percentages with which delays fall
+// into each of the three different clusters, and the standard deviation for
+// the normalized distribution
+// This can be used to generate a number of scenarios typical of latency
+// distribution among peers on the internet
+func InternetLatencyDelayGenerator(
+	mediumDelay time.Duration,
+	largeDelay time.Duration,
+	percentMedium float64,
+	percentLarge float64,
+	std time.Duration,
+	rng *rand.Rand) delay.Generator {
+	if rng == nil {
+		rng = sharedRNG
+	}
+
+	return &internetLatencyDelayGenerator{
+		mediumDelay:   mediumDelay,
+		largeDelay:    largeDelay,
+		percentLarge:  percentLarge,
+		percentMedium: percentMedium,
+		std:           std,
+		rng:           rng,
+	}
+}
+
+type internetLatencyDelayGenerator struct {
+	mediumDelay   time.Duration
+	largeDelay    time.Duration
+	percentLarge  float64
+	percentMedium float64
+	std           time.Duration
+	rng           *rand.Rand
+}
+
+func (d *internetLatencyDelayGenerator) NextWaitTime(t time.Duration) time.Duration {
+	clusterDistribution := d.rng.Float64()
+	baseDelay := time.Duration(d.rng.NormFloat64()*float64(d.std)) + t
+	if clusterDistribution < d.percentLarge {
+		return baseDelay + d.largeDelay
+	} else if clusterDistribution < d.percentMedium+d.percentLarge {
+		return baseDelay + d.mediumDelay
+	}
+	return baseDelay
+}

--- a/testnet/internet_latency_delay_generator_test.go
+++ b/testnet/internet_latency_delay_generator_test.go
@@ -1,0 +1,69 @@
+package bitswap
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+const testSeed = 99
+
+func TestInternetLatencyDelayNextWaitTimeDistribution(t *testing.T) {
+	initialValue := 1000 * time.Millisecond
+	deviation := 100 * time.Millisecond
+	mediumDelay := 1000 * time.Millisecond
+	largeDelay := 3000 * time.Millisecond
+	percentMedium := 0.2
+	percentLarge := 0.4
+	buckets := make(map[string]int)
+	internetLatencyDistributionDelay := InternetLatencyDelayGenerator(
+		mediumDelay,
+		largeDelay,
+		percentMedium,
+		percentLarge,
+		deviation,
+		rand.New(rand.NewSource(testSeed)))
+
+	buckets["fast"] = 0
+	buckets["medium"] = 0
+	buckets["slow"] = 0
+	buckets["outside_1_deviation"] = 0
+
+	// strategy here is rather than mock randomness, just use enough samples to
+	// get approximately the distribution you'd expect
+	for i := 0; i < 10000; i++ {
+		next := internetLatencyDistributionDelay.NextWaitTime(initialValue)
+		if math.Abs((next - initialValue).Seconds()) <= deviation.Seconds() {
+			buckets["fast"]++
+		} else if math.Abs((next - initialValue - mediumDelay).Seconds()) <= deviation.Seconds() {
+			buckets["medium"]++
+		} else if math.Abs((next - initialValue - largeDelay).Seconds()) <= deviation.Seconds() {
+			buckets["slow"]++
+		} else {
+			buckets["outside_1_deviation"]++
+		}
+	}
+	totalInOneDeviation := float64(10000 - buckets["outside_1_deviation"])
+	oneDeviationPercentage := totalInOneDeviation / 10000
+	fastPercentageResult := float64(buckets["fast"]) / totalInOneDeviation
+	mediumPercentageResult := float64(buckets["medium"]) / totalInOneDeviation
+	slowPercentageResult := float64(buckets["slow"]) / totalInOneDeviation
+
+	// see 68-95-99 rule for normal distributions
+	if math.Abs(oneDeviationPercentage-0.6827) >= 0.1 {
+		t.Fatal("Failed to distribute values normally based on standard deviation")
+	}
+
+	if math.Abs(fastPercentageResult+percentMedium+percentLarge-1) >= 0.1 {
+		t.Fatal("Incorrect percentage of values distributed around fast delay time")
+	}
+
+	if math.Abs(mediumPercentageResult-percentMedium) >= 0.1 {
+		t.Fatal("Incorrect percentage of values distributed around medium delay time")
+	}
+
+	if math.Abs(slowPercentageResult-percentLarge) >= 0.1 {
+		t.Fatal("Incorrect percentage of values distributed around slow delay time")
+	}
+}


### PR DESCRIPTION
# Goals

Build a benchmark that can replicate the problems that #8 has with LS-ing Wikipedia

# Implementation

- add a delay generator that similates real world latencies one might encounter on the internet
- modify virtual network to accept different latencies for different
peers based on using NextWaitTime on passed delay
- modify dup_blocks_test subtestDistributeAndFetch to accept a custom
delay
- Add a real world benchmarks that simulates the kinds of problems one might
encounter bitswaping with a long lived session and a large swarm of
peers with real world latency distributions (that causes #8 not to
function well in practice)

# For Discussion

The goal here is to have a good benchmark to compare against as we continue to develop improvements to bitswap.

One thing not addressed here are transfer speeds (though you can think of latency in this test as really being time to first byte -- i.e. traditional latency -- + download time). Is that worth addressing seperately.

Benchmarks with results posted in comment.



