### PR TITLE
Bitswap Refactor #4: Extract session peer manager from sessions

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -16,9 +16,10 @@ import (
 	bsnet "github.com/ipfs/go-bitswap/network"
 	notifications "github.com/ipfs/go-bitswap/notifications"
 	bspm "github.com/ipfs/go-bitswap/peermanager"
+	bssession "github.com/ipfs/go-bitswap/session"
 	bssm "github.com/ipfs/go-bitswap/sessionmanager"
+	bsspm "github.com/ipfs/go-bitswap/sessionpeermanager"
 	bswm "github.com/ipfs/go-bitswap/wantmanager"
-
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
@@ -102,6 +103,13 @@ func New(parent context.Context, network bsnet.BitSwapNetwork,
 	}
 
 	wm := bswm.New(ctx)
+	sessionFactory := func(ctx context.Context, id uint64, pm bssession.PeerManager) bssm.Session {
+		return bssession.New(ctx, id, wm, pm)
+	}
+	sessionPeerManagerFactory := func(ctx context.Context, id uint64) bssession.PeerManager {
+		return bsspm.New(ctx, id, network)
+	}
+
 	bs := &Bitswap{
 		blockstore:    bstore,
 		notifications: notif,
@@ -113,7 +121,7 @@ func New(parent context.Context, network bsnet.BitSwapNetwork,
 		provideKeys:   make(chan cid.Cid, provideKeysBufferSize),
 		wm:            wm,
 		pm:            bspm.New(ctx, peerQueueFactory),
-		sm:            bssm.New(ctx, wm, network),
+		sm:            bssm.New(ctx, sessionFactory, sessionPeerManagerFactory),
 		counters:      new(counters),
 		dupMetric:     dupHist,
 		allMetric:     allHist,

--- a/session/cidqueue.go
+++ b/session/cidqueue.go
@@ -1,0 +1,46 @@
+package session
+
+import cid "github.com/ipfs/go-cid"
+
+type cidQueue struct {
+	elems []cid.Cid
+	eset  *cid.Set
+}
+
+func newCidQueue() *cidQueue {
+	return &cidQueue{eset: cid.NewSet()}
+}
+
+func (cq *cidQueue) Pop() cid.Cid {
+	for {
+		if len(cq.elems) == 0 {
+			return cid.Cid{}
+		}
+
+		out := cq.elems[0]
+		cq.elems = cq.elems[1:]
+
+		if cq.eset.Has(out) {
+			cq.eset.Remove(out)
+			return out
+		}
+	}
+}
+
+func (cq *cidQueue) Push(c cid.Cid) {
+	if cq.eset.Visit(c) {
+		cq.elems = append(cq.elems, c)
+	}
+}
+
+func (cq *cidQueue) Remove(c cid.Cid) {
+	cq.eset.Remove(c)
+}
+
+func (cq *cidQueue) Has(c cid.Cid) bool {
+	return cq.eset.Has(c)
+}
+
+func (cq *cidQueue) Len() int {
+	return cq.eset.Len()
+}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,0 +1,229 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-block-format"
+
+	"github.com/ipfs/go-bitswap/testutil"
+	cid "github.com/ipfs/go-cid"
+	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+type wantReq struct {
+	cids     []cid.Cid
+	peers    []peer.ID
+	isCancel bool
+}
+
+type fakeWantManager struct {
+	lk       sync.RWMutex
+	wantReqs []wantReq
+}
+
+func (fwm *fakeWantManager) WantBlocks(ctx context.Context, cids []cid.Cid, peers []peer.ID, ses uint64) {
+	fwm.lk.Lock()
+	fwm.wantReqs = append(fwm.wantReqs, wantReq{cids, peers, false})
+	fwm.lk.Unlock()
+}
+
+func (fwm *fakeWantManager) CancelWants(ctx context.Context, cids []cid.Cid, peers []peer.ID, ses uint64) {
+	fwm.lk.Lock()
+	fwm.wantReqs = append(fwm.wantReqs, wantReq{cids, peers, true})
+	fwm.lk.Unlock()
+}
+
+type fakePeerManager struct {
+	peers                  []peer.ID
+	findMorePeersRequested bool
+}
+
+func (fpm *fakePeerManager) FindMorePeers(context.Context, cid.Cid) {
+	fpm.findMorePeersRequested = true
+}
+
+func (fpm *fakePeerManager) GetOptimizedPeers() []peer.ID {
+	return fpm.peers
+}
+
+func (fpm *fakePeerManager) RecordPeerRequests([]peer.ID, []cid.Cid) {}
+func (fpm *fakePeerManager) RecordPeerResponse(p peer.ID, c cid.Cid) {
+	fpm.peers = append(fpm.peers, p)
+}
+
+func TestSessionGetBlocks(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	fwm := &fakeWantManager{}
+	fpm := &fakePeerManager{}
+	id := testutil.GenerateSessionID()
+	session := New(ctx, id, fwm, fpm)
+	blockGenerator := blocksutil.NewBlockGenerator()
+	blks := blockGenerator.Blocks(activeWantsLimit * 2)
+	var cids []cid.Cid
+	for _, block := range blks {
+		cids = append(cids, block.Cid())
+	}
+	var receivedBlocks []blocks.Block
+	getBlocksCh, err := session.GetBlocks(ctx, cids)
+	go func() {
+		for block := range getBlocksCh {
+			receivedBlocks = append(receivedBlocks, block)
+		}
+	}()
+	if err != nil {
+		t.Fatal("error getting blocks")
+	}
+
+	// check initial want request
+	time.Sleep(3 * time.Millisecond)
+	if len(fwm.wantReqs) != 1 {
+		t.Fatal("failed to enqueue wants")
+	}
+	fwm.lk.Lock()
+	receivedWantReq := fwm.wantReqs[0]
+	if len(receivedWantReq.cids) != activeWantsLimit {
+		t.Fatal("did not enqueue correct initial number of wants")
+	}
+	if receivedWantReq.peers != nil {
+		t.Fatal("first want request should be a broadcast")
+	}
+
+	fwm.wantReqs = nil
+	fwm.lk.Unlock()
+
+	// now receive the first set of blocks
+	peers := testutil.GeneratePeers(activeWantsLimit)
+	for i, p := range peers {
+		session.ReceiveBlockFrom(p, blks[i])
+	}
+	time.Sleep(3 * time.Millisecond)
+
+	// verify new peers were recorded
+	if len(fpm.peers) != activeWantsLimit {
+		t.Fatal("received blocks not recorded by the peer manager")
+	}
+	for _, p := range fpm.peers {
+		if !testutil.ContainsPeer(peers, p) {
+			t.Fatal("incorrect peer recorded to peer manager")
+		}
+	}
+
+	// look at new interactions with want manager
+	var cancelReqs []wantReq
+	var newBlockReqs []wantReq
+
+	fwm.lk.Lock()
+	for _, w := range fwm.wantReqs {
+		if w.isCancel {
+			cancelReqs = append(cancelReqs, w)
+		} else {
+			newBlockReqs = append(newBlockReqs, w)
+		}
+	}
+	// should have cancelled each received block
+	if len(cancelReqs) != activeWantsLimit {
+		t.Fatal("did not cancel each block once it was received")
+	}
+	// new session reqs should be targeted
+	totalEnqueued := 0
+	for _, w := range newBlockReqs {
+		if len(w.peers) == 0 {
+			t.Fatal("should not have broadcast again after initial broadcast")
+		}
+		totalEnqueued += len(w.cids)
+	}
+	fwm.lk.Unlock()
+
+	// full new round of cids should be requested
+	if totalEnqueued != activeWantsLimit {
+		t.Fatal("new blocks were not requested")
+	}
+
+	// receive remaining blocks
+	for i, p := range peers {
+		session.ReceiveBlockFrom(p, blks[i+activeWantsLimit])
+	}
+
+	// wait for everything to wrap up
+	<-ctx.Done()
+
+	// check that we got everything
+	fmt.Printf("%d\n", len(receivedBlocks))
+
+	if len(receivedBlocks) != len(blks) {
+		t.Fatal("did not receive enough blocks")
+	}
+	for _, block := range receivedBlocks {
+		if !testutil.ContainsBlock(blks, block) {
+			t.Fatal("received incorrect block")
+		}
+	}
+}
+
+func TestSessionFindMorePeers(t *testing.T) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	fwm := &fakeWantManager{}
+	fpm := &fakePeerManager{}
+	id := testutil.GenerateSessionID()
+	session := New(ctx, id, fwm, fpm)
+	session.SetBaseTickDelay(1 * time.Millisecond)
+	blockGenerator := blocksutil.NewBlockGenerator()
+	blks := blockGenerator.Blocks(activeWantsLimit * 2)
+	var cids []cid.Cid
+	for _, block := range blks {
+		cids = append(cids, block.Cid())
+	}
+	var receivedBlocks []blocks.Block
+	getBlocksCh, err := session.GetBlocks(ctx, cids)
+	go func() {
+		for block := range getBlocksCh {
+			receivedBlocks = append(receivedBlocks, block)
+		}
+	}()
+	if err != nil {
+		t.Fatal("error getting blocks")
+	}
+
+	// receive a block to trigger a tick reset
+	time.Sleep(1 * time.Millisecond)
+	p := testutil.GeneratePeers(1)[0]
+	session.ReceiveBlockFrom(p, blks[0])
+
+	// wait then clear the want list
+	time.Sleep(1 * time.Millisecond)
+	fwm.lk.Lock()
+	fwm.wantReqs = nil
+	fwm.lk.Unlock()
+
+	// wait long enough for a tick to occur
+	// baseTickDelay + 3 * latency = 4ms
+	time.Sleep(6 * time.Millisecond)
+
+	// trigger to find providers should have happened
+	if fpm.findMorePeersRequested != true {
+		t.Fatal("should have attempted to find more peers but didn't")
+	}
+
+	// verify a broadcast was made
+	fwm.lk.Lock()
+	if len(fwm.wantReqs) != 1 {
+		t.Fatal("did not make a new broadcast")
+	}
+	receivedWantReq := fwm.wantReqs[0]
+	if len(receivedWantReq.cids) != activeWantsLimit {
+		t.Fatal("did not rebroadcast whole live list")
+	}
+	if receivedWantReq.peers != nil {
+		t.Fatal("did not make a broadcast")
+	}
+	fwm.wantReqs = nil
+	fwm.lk.Unlock()
+}

--- a/sessionmanager/sessionmanager_test.go
+++ b/sessionmanager/sessionmanager_test.go
@@ -1,0 +1,163 @@
+package sessionmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	bssession "github.com/ipfs/go-bitswap/session"
+
+	blocks "github.com/ipfs/go-block-format"
+	cid "github.com/ipfs/go-cid"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+type fakeSession struct {
+	interested    bool
+	receivedBlock bool
+	id            uint64
+	pm            *fakePeerManager
+}
+
+func (*fakeSession) GetBlock(context.Context, cid.Cid) (blocks.Block, error) {
+	return nil, nil
+}
+func (*fakeSession) GetBlocks(context.Context, []cid.Cid) (<-chan blocks.Block, error) {
+	return nil, nil
+}
+func (fs *fakeSession) InterestedIn(cid.Cid) bool              { return fs.interested }
+func (fs *fakeSession) ReceiveBlockFrom(peer.ID, blocks.Block) { fs.receivedBlock = true }
+
+type fakePeerManager struct {
+	id uint64
+}
+
+func (*fakePeerManager) FindMorePeers(context.Context, cid.Cid)  {}
+func (*fakePeerManager) GetOptimizedPeers() []peer.ID            { return nil }
+func (*fakePeerManager) RecordPeerRequests([]peer.ID, []cid.Cid) {}
+func (*fakePeerManager) RecordPeerResponse(peer.ID, cid.Cid)     {}
+
+var nextInterestedIn bool
+
+func sessionFactory(ctx context.Context, id uint64, pm bssession.PeerManager) Session {
+	return &fakeSession{
+		interested:    nextInterestedIn,
+		receivedBlock: false,
+		id:            id,
+		pm:            pm.(*fakePeerManager),
+	}
+}
+
+func peerManagerFactory(ctx context.Context, id uint64) bssession.PeerManager {
+	return &fakePeerManager{id}
+}
+
+func TestAddingSessions(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	sm := New(ctx, sessionFactory, peerManagerFactory)
+
+	p := peer.ID(123)
+	block := blocks.NewBlock([]byte("block"))
+	// we'll be interested in all blocks for this test
+	nextInterestedIn = true
+
+	currentID := sm.GetNextSessionID()
+	firstSession := sm.NewSession(ctx).(*fakeSession)
+	if firstSession.id != firstSession.pm.id ||
+		firstSession.id != currentID+1 {
+		t.Fatal("session does not have correct id set")
+	}
+	secondSession := sm.NewSession(ctx).(*fakeSession)
+	if secondSession.id != secondSession.pm.id ||
+		secondSession.id != firstSession.id+1 {
+		t.Fatal("session does not have correct id set")
+	}
+	sm.GetNextSessionID()
+	thirdSession := sm.NewSession(ctx).(*fakeSession)
+	if thirdSession.id != thirdSession.pm.id ||
+		thirdSession.id != secondSession.id+2 {
+		t.Fatal("session does not have correct id set")
+	}
+	sm.ReceiveBlockFrom(p, block)
+	if !firstSession.receivedBlock ||
+		!secondSession.receivedBlock ||
+		!thirdSession.receivedBlock {
+		t.Fatal("should have received blocks but didn't")
+	}
+}
+
+func TestReceivingBlocksWhenNotInterested(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	sm := New(ctx, sessionFactory, peerManagerFactory)
+
+	p := peer.ID(123)
+	block := blocks.NewBlock([]byte("block"))
+	// we'll be interested in all blocks for this test
+	nextInterestedIn = false
+	firstSession := sm.NewSession(ctx).(*fakeSession)
+	nextInterestedIn = true
+	secondSession := sm.NewSession(ctx).(*fakeSession)
+	nextInterestedIn = false
+	thirdSession := sm.NewSession(ctx).(*fakeSession)
+
+	sm.ReceiveBlockFrom(p, block)
+	if firstSession.receivedBlock ||
+		!secondSession.receivedBlock ||
+		thirdSession.receivedBlock {
+		t.Fatal("did not receive blocks only for interested sessions")
+	}
+}
+
+func TestRemovingPeersWhenManagerContextCancelled(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	sm := New(ctx, sessionFactory, peerManagerFactory)
+
+	p := peer.ID(123)
+	block := blocks.NewBlock([]byte("block"))
+	// we'll be interested in all blocks for this test
+	nextInterestedIn = true
+	firstSession := sm.NewSession(ctx).(*fakeSession)
+	secondSession := sm.NewSession(ctx).(*fakeSession)
+	thirdSession := sm.NewSession(ctx).(*fakeSession)
+
+	cancel()
+	// wait for sessions to get removed
+	time.Sleep(10 * time.Millisecond)
+	sm.ReceiveBlockFrom(p, block)
+	if firstSession.receivedBlock ||
+		secondSession.receivedBlock ||
+		thirdSession.receivedBlock {
+		t.Fatal("received blocks for sessions after manager is shutdown")
+	}
+}
+
+func TestRemovingPeersWhenSessionContextCancelled(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	sm := New(ctx, sessionFactory, peerManagerFactory)
+
+	p := peer.ID(123)
+	block := blocks.NewBlock([]byte("block"))
+	// we'll be interested in all blocks for this test
+	nextInterestedIn = true
+	firstSession := sm.NewSession(ctx).(*fakeSession)
+	sessionCtx, sessionCancel := context.WithCancel(ctx)
+	secondSession := sm.NewSession(sessionCtx).(*fakeSession)
+	thirdSession := sm.NewSession(ctx).(*fakeSession)
+
+	sessionCancel()
+	// wait for sessions to get removed
+	time.Sleep(10 * time.Millisecond)
+	sm.ReceiveBlockFrom(p, block)
+	if !firstSession.receivedBlock ||
+		secondSession.receivedBlock ||
+		!thirdSession.receivedBlock {
+		t.Fatal("received blocks for sessions that are canceled")
+	}
+}

--- a/sessionpeermanager/sessionpeermanager.go
+++ b/sessionpeermanager/sessionpeermanager.go
@@ -1,0 +1,118 @@
+package sessionpeermanager
+
+import (
+	"context"
+	"fmt"
+
+	cid "github.com/ipfs/go-cid"
+	ifconnmgr "github.com/libp2p/go-libp2p-interface-connmgr"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+type PeerNetwork interface {
+	ConnectionManager() ifconnmgr.ConnManager
+	FindProvidersAsync(context.Context, cid.Cid, int) <-chan peer.ID
+}
+
+type SessionPeerManager struct {
+	ctx     context.Context
+	network PeerNetwork
+	tag     string
+
+	newPeers chan peer.ID
+	peerReqs chan chan []peer.ID
+
+	// do not touch outside of run loop
+	activePeers    map[peer.ID]struct{}
+	activePeersArr []peer.ID
+}
+
+func New(ctx context.Context, id uint64, network PeerNetwork) *SessionPeerManager {
+	spm := &SessionPeerManager{
+		ctx:         ctx,
+		network:     network,
+		newPeers:    make(chan peer.ID, 16),
+		peerReqs:    make(chan chan []peer.ID),
+		activePeers: make(map[peer.ID]struct{}),
+	}
+
+	spm.tag = fmt.Sprint("bs-ses-", id)
+
+	go spm.run(ctx)
+	return spm
+}
+
+func (spm *SessionPeerManager) RecordPeerResponse(p peer.ID, k cid.Cid) {
+	// at the moment, we're just adding peers here
+	// in the future, we'll actually use this to record metrics
+	select {
+	case spm.newPeers <- p:
+	case <-spm.ctx.Done():
+	}
+}
+
+func (spm *SessionPeerManager) RecordPeerRequests(p []peer.ID, ks []cid.Cid) {
+	// at the moment, we're not doing anything here
+	// soon we'll use this to track latency by peer
+}
+
+func (spm *SessionPeerManager) GetOptimizedPeers() []peer.ID {
+	// right now this just returns all peers, but soon we might return peers
+	// ordered by optimization, or only a subset
+	resp := make(chan []peer.ID)
+	select {
+	case spm.peerReqs <- resp:
+	case <-spm.ctx.Done():
+		return nil
+	}
+
+	select {
+	case peers := <-resp:
+		return peers
+	case <-spm.ctx.Done():
+		return nil
+	}
+}
+
+func (spm *SessionPeerManager) FindMorePeers(ctx context.Context, c cid.Cid) {
+	go func(k cid.Cid) {
+		// TODO: have a task queue setup for this to:
+		// - rate limit
+		// - manage timeouts
+		// - ensure two 'findprovs' calls for the same block don't run concurrently
+		// - share peers between sessions based on interest set
+		for p := range spm.network.FindProvidersAsync(ctx, k, 10) {
+			spm.newPeers <- p
+		}
+	}(c)
+}
+
+func (spm *SessionPeerManager) run(ctx context.Context) {
+	for {
+		select {
+		case p := <-spm.newPeers:
+			spm.addActivePeer(p)
+		case resp := <-spm.peerReqs:
+			resp <- spm.activePeersArr
+		case <-ctx.Done():
+			spm.handleShutdown()
+			return
+		}
+	}
+}
+func (spm *SessionPeerManager) addActivePeer(p peer.ID) {
+	if _, ok := spm.activePeers[p]; !ok {
+		spm.activePeers[p] = struct{}{}
+		spm.activePeersArr = append(spm.activePeersArr, p)
+
+		cmgr := spm.network.ConnectionManager()
+		cmgr.TagPeer(p, spm.tag, 10)
+	}
+}
+
+func (spm *SessionPeerManager) handleShutdown() {
+	cmgr := spm.network.ConnectionManager()
+	for _, p := range spm.activePeersArr {
+		cmgr.UntagPeer(p, spm.tag)
+	}
+}

--- a/sessionpeermanager/sessionpeermanager.go
+++ b/sessionpeermanager/sessionpeermanager.go
@@ -9,11 +9,14 @@ import (
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
+// PeerNetwork is an interface for finding providers and managing connections
 type PeerNetwork interface {
 	ConnectionManager() ifconnmgr.ConnManager
 	FindProvidersAsync(context.Context, cid.Cid, int) <-chan peer.ID
 }
 
+// SessionPeerManager tracks and manages peers for a session, and provides
+// the best ones to the session
 type SessionPeerManager struct {
 	ctx     context.Context
 	network PeerNetwork
@@ -27,6 +30,7 @@ type SessionPeerManager struct {
 	activePeersArr []peer.ID
 }
 
+// New creates a new SessionPeerManager
 func New(ctx context.Context, id uint64, network PeerNetwork) *SessionPeerManager {
 	spm := &SessionPeerManager{
 		ctx:         ctx,
@@ -42,7 +46,10 @@ func New(ctx context.Context, id uint64, network PeerNetwork) *SessionPeerManage
 	return spm
 }
 
+// RecordPeerResponse records that a peer received a block, and adds to it
+// the list of peers if it wasn't already added
 func (spm *SessionPeerManager) RecordPeerResponse(p peer.ID, k cid.Cid) {
+
 	// at the moment, we're just adding peers here
 	// in the future, we'll actually use this to record metrics
 	select {
@@ -51,11 +58,13 @@ func (spm *SessionPeerManager) RecordPeerResponse(p peer.ID, k cid.Cid) {
 	}
 }
 
+// RecordPeerRequests records that a given set of peers requested the given cids
 func (spm *SessionPeerManager) RecordPeerRequests(p []peer.ID, ks []cid.Cid) {
 	// at the moment, we're not doing anything here
 	// soon we'll use this to track latency by peer
 }
 
+// GetOptimizedPeers returns the best peers available for a session
 func (spm *SessionPeerManager) GetOptimizedPeers() []peer.ID {
 	// right now this just returns all peers, but soon we might return peers
 	// ordered by optimization, or only a subset
@@ -74,6 +83,8 @@ func (spm *SessionPeerManager) GetOptimizedPeers() []peer.ID {
 	}
 }
 
+// FindMorePeers attempts to find more peers for a session by searching for
+// providers for the given Cid
 func (spm *SessionPeerManager) FindMorePeers(ctx context.Context, c cid.Cid) {
 	go func(k cid.Cid) {
 		// TODO: have a task queue setup for this to:

--- a/sessionpeermanager/sessionpeermanager_test.go
+++ b/sessionpeermanager/sessionpeermanager_test.go
@@ -1,0 +1,136 @@
+package sessionpeermanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-bitswap/testutil"
+
+	cid "github.com/ipfs/go-cid"
+	ifconnmgr "github.com/libp2p/go-libp2p-interface-connmgr"
+	inet "github.com/libp2p/go-libp2p-net"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+type fakePeerNetwork struct {
+	peers       []peer.ID
+	connManager ifconnmgr.ConnManager
+}
+
+func (fpn *fakePeerNetwork) ConnectionManager() ifconnmgr.ConnManager {
+	return fpn.connManager
+}
+
+func (fpn *fakePeerNetwork) FindProvidersAsync(ctx context.Context, c cid.Cid, num int) <-chan peer.ID {
+	peerCh := make(chan peer.ID)
+	go func() {
+		defer close(peerCh)
+		for _, p := range fpn.peers {
+			select {
+			case peerCh <- p:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return peerCh
+}
+
+type fakeConnManager struct {
+	taggedPeers []peer.ID
+}
+
+func (fcm *fakeConnManager) TagPeer(p peer.ID, tag string, n int) {
+	fcm.taggedPeers = append(fcm.taggedPeers, p)
+}
+func (fcm *fakeConnManager) UntagPeer(p peer.ID, tag string) {
+	for i := 0; i < len(fcm.taggedPeers); i++ {
+		if fcm.taggedPeers[i] == p {
+			fcm.taggedPeers[i] = fcm.taggedPeers[len(fcm.taggedPeers)-1]
+			fcm.taggedPeers = fcm.taggedPeers[:len(fcm.taggedPeers)-1]
+			return
+		}
+	}
+}
+func (*fakeConnManager) GetTagInfo(p peer.ID) *ifconnmgr.TagInfo { return nil }
+func (*fakeConnManager) TrimOpenConns(ctx context.Context)       {}
+func (*fakeConnManager) Notifee() inet.Notifiee                  { return nil }
+
+func TestFindingMorePeers(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	peers := testutil.GeneratePeers(5)
+	fcm := &fakeConnManager{}
+	fpn := &fakePeerNetwork{peers, fcm}
+	c := testutil.GenerateCids(1)[0]
+	id := testutil.GenerateSessionID()
+
+	sessionPeerManager := New(ctx, id, fpn)
+
+	findCtx, findCancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	defer findCancel()
+	sessionPeerManager.FindMorePeers(ctx, c)
+	<-findCtx.Done()
+	sessionPeers := sessionPeerManager.GetOptimizedPeers()
+	if len(sessionPeers) != len(peers) {
+		t.Fatal("incorrect number of peers found")
+	}
+	for _, p := range sessionPeers {
+		if !testutil.ContainsPeer(peers, p) {
+			t.Fatal("incorrect peer found through finding providers")
+		}
+	}
+	if len(fcm.taggedPeers) != len(peers) {
+		t.Fatal("Peers were not tagged!")
+	}
+}
+
+func TestRecordingReceivedBlocks(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	p := testutil.GeneratePeers(1)[0]
+	fcm := &fakeConnManager{}
+	fpn := &fakePeerNetwork{nil, fcm}
+	c := testutil.GenerateCids(1)[0]
+	id := testutil.GenerateSessionID()
+
+	sessionPeerManager := New(ctx, id, fpn)
+	sessionPeerManager.RecordPeerResponse(p, c)
+	time.Sleep(10 * time.Millisecond)
+	sessionPeers := sessionPeerManager.GetOptimizedPeers()
+	if len(sessionPeers) != 1 {
+		t.Fatal("did not add peer on receive")
+	}
+	if sessionPeers[0] != p {
+		t.Fatal("incorrect peer added on receive")
+	}
+	if len(fcm.taggedPeers) != 1 {
+		t.Fatal("Peers was not tagged!")
+	}
+}
+
+func TestUntaggingPeers(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	defer cancel()
+	peers := testutil.GeneratePeers(5)
+	fcm := &fakeConnManager{}
+	fpn := &fakePeerNetwork{peers, fcm}
+	c := testutil.GenerateCids(1)[0]
+	id := testutil.GenerateSessionID()
+
+	sessionPeerManager := New(ctx, id, fpn)
+
+	sessionPeerManager.FindMorePeers(ctx, c)
+	time.Sleep(5 * time.Millisecond)
+	if len(fcm.taggedPeers) != len(peers) {
+		t.Fatal("Peers were not tagged!")
+	}
+	<-ctx.Done()
+	if len(fcm.taggedPeers) != 0 {
+		t.Fatal("Peers were not untagged!")
+	}
+}

--- a/sessionpeermanager/sessionpeermanager_test.go
+++ b/sessionpeermanager/sessionpeermanager_test.go
@@ -130,6 +130,7 @@ func TestUntaggingPeers(t *testing.T) {
 		t.Fatal("Peers were not tagged!")
 	}
 	<-ctx.Done()
+	time.Sleep(5 * time.Millisecond)
 	if len(fcm.taggedPeers) != 0 {
 		t.Fatal("Peers were not untagged!")
 	}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	bsmsg "github.com/ipfs/go-bitswap/message"
 	"github.com/ipfs/go-bitswap/wantlist"
+	"github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
 	peer "github.com/libp2p/go-libp2p-peer"
@@ -71,6 +72,16 @@ func GenerateSessionID() uint64 {
 func ContainsPeer(peers []peer.ID, p peer.ID) bool {
 	for _, n := range peers {
 		if p == n {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsBlock returns true if a block is found n a list of blocks
+func ContainsBlock(blks []blocks.Block, block blocks.Block) bool {
+	for _, n := range blks {
+		if block.Cid() == n.Cid() {
 			return true
 		}
 	}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -78,12 +78,17 @@ func ContainsPeer(peers []peer.ID, p peer.ID) bool {
 	return false
 }
 
-// ContainsBlock returns true if a block is found n a list of blocks
-func ContainsBlock(blks []blocks.Block, block blocks.Block) bool {
-	for _, n := range blks {
-		if block.Cid() == n.Cid() {
-			return true
+// IndexOf returns the index of a given cid in an array of blocks
+func IndexOf(blks []blocks.Block, c cid.Cid) int {
+	for i, n := range blks {
+		if n.Cid() == c {
+			return i
 		}
 	}
-	return false
+	return -1
+}
+
+// ContainsBlock returns true if a block is found n a list of blocks
+func ContainsBlock(blks []blocks.Block, block blocks.Block) bool {
+	return IndexOf(blks, block.Cid()) != -1
 }


### PR DESCRIPTION
# Goals

Modularize Bitswap in preparation for attempts to optimize bitswap further

This also gets us quite a bit of the way toward the proposed split of bitswap into low level "just ask for blocks from peers and respond to requests" bitswap and high level bitswap -- sessions, and possibly other drivers as time goes on.

# Implementation

Final PR includes:
- Extracted out the managing of peers for a session into it's own backage -- this way, tracking optimal peers is seperate from improving algorithms for fetch blocks
- Commented all exported functions to 
- Unit test new session manager, new session peermanager
- Unit test sessions (they are currently really more integration tested in the main package)
 
# For discussion

child of https://github.com/ipfs/go-ipfs/issues/5723