### PR TITLE
Speed up sessions Round #1

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -391,7 +391,7 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 			defer wg.Done()
 
 			bs.updateReceiveCounters(b)
-
+			bs.sm.UpdateReceiveCounters(b)
 			log.Debugf("got block %s from %s", b, p)
 
 			// skip received blocks that are not in the wantlist

--- a/bitswap.go
+++ b/bitswap.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	bssrs "github.com/ipfs/go-bitswap/sessionrequestsplitter"
+
 	decision "github.com/ipfs/go-bitswap/decision"
 	bsgetter "github.com/ipfs/go-bitswap/getter"
 	bsmsg "github.com/ipfs/go-bitswap/message"
@@ -103,11 +105,14 @@ func New(parent context.Context, network bsnet.BitSwapNetwork,
 	}
 
 	wm := bswm.New(ctx)
-	sessionFactory := func(ctx context.Context, id uint64, pm bssession.PeerManager) bssm.Session {
-		return bssession.New(ctx, id, wm, pm)
+	sessionFactory := func(ctx context.Context, id uint64, pm bssession.PeerManager, srs bssession.RequestSplitter) bssm.Session {
+		return bssession.New(ctx, id, wm, pm, srs)
 	}
 	sessionPeerManagerFactory := func(ctx context.Context, id uint64) bssession.PeerManager {
 		return bsspm.New(ctx, id, network)
+	}
+	sessionRequestSplitterFactory := func(ctx context.Context) bssession.RequestSplitter {
+		return bssrs.New(ctx)
 	}
 
 	bs := &Bitswap{
@@ -121,7 +126,7 @@ func New(parent context.Context, network bsnet.BitSwapNetwork,
 		provideKeys:   make(chan cid.Cid, provideKeysBufferSize),
 		wm:            wm,
 		pm:            bspm.New(ctx, peerQueueFactory),
-		sm:            bssm.New(ctx, sessionFactory, sessionPeerManagerFactory),
+		sm:            bssm.New(ctx, sessionFactory, sessionPeerManagerFactory, sessionRequestSplitterFactory),
 		counters:      new(counters),
 		dupMetric:     dupHist,
 		allMetric:     allHist,

--- a/session/session.go
+++ b/session/session.go
@@ -341,8 +341,16 @@ func (s *Session) receiveBlock(ctx context.Context, blk blocks.Block) {
 		s.fetchcnt++
 		s.notif.Publish(blk)
 
-		if next := s.tofetch.Pop(); next.Defined() {
-			s.wantBlocks(ctx, []cid.Cid{next})
+		toAdd := s.wantBudget()
+		if toAdd > s.tofetch.Len() {
+			toAdd = s.tofetch.Len()
+		}
+		if toAdd > 0 {
+			var keys []cid.Cid
+			for i := 0; i < toAdd; i++ {
+				keys = append(keys, s.tofetch.Pop())
+			}
+			s.wantBlocks(ctx, keys)
 		}
 
 		s.pastWants.Push(c)

--- a/session/session.go
+++ b/session/session.go
@@ -333,6 +333,7 @@ func (s *Session) cidIsWanted(c cid.Cid) bool {
 func (s *Session) receiveBlock(ctx context.Context, blk blocks.Block) {
 	c := blk.Cid()
 	if s.cidIsWanted(c) {
+		s.srs.RecordUniqueBlock()
 		tval, ok := s.liveWants[c]
 		if ok {
 			s.latTotal += time.Since(tval)
@@ -363,10 +364,6 @@ func (s *Session) updateReceiveCounters(ctx context.Context, blk blkRecv) {
 	ks := blk.blk.Cid()
 	if s.pastWants.Has(ks) {
 		s.srs.RecordDuplicateBlock()
-	} else {
-		if s.cidIsWanted(ks) {
-			s.srs.RecordUniqueBlock()
-		}
 	}
 }
 

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -65,7 +65,7 @@ func TestSessionGetBlocks(t *testing.T) {
 	id := testutil.GenerateSessionID()
 	session := New(ctx, id, fwm, fpm)
 	blockGenerator := blocksutil.NewBlockGenerator()
-	blks := blockGenerator.Blocks(activeWantsLimit * 2)
+	blks := blockGenerator.Blocks(broadcastLiveWantsLimit * 2)
 	var cids []cid.Cid
 	for _, block := range blks {
 		cids = append(cids, block.Cid())
@@ -79,7 +79,7 @@ func TestSessionGetBlocks(t *testing.T) {
 	// check initial want request
 	receivedWantReq := <-fwm.wantReqs
 
-	if len(receivedWantReq.cids) != activeWantsLimit {
+	if len(receivedWantReq.cids) != broadcastLiveWantsLimit {
 		t.Fatal("did not enqueue correct initial number of wants")
 	}
 	if receivedWantReq.peers != nil {
@@ -87,7 +87,7 @@ func TestSessionGetBlocks(t *testing.T) {
 	}
 
 	// now receive the first set of blocks
-	peers := testutil.GeneratePeers(activeWantsLimit)
+	peers := testutil.GeneratePeers(broadcastLiveWantsLimit)
 	var newCancelReqs []wantReq
 	var newBlockReqs []wantReq
 	var receivedBlocks []blocks.Block
@@ -103,7 +103,7 @@ func TestSessionGetBlocks(t *testing.T) {
 
 	// verify new peers were recorded
 	fpm.lk.Lock()
-	if len(fpm.peers) != activeWantsLimit {
+	if len(fpm.peers) != broadcastLiveWantsLimit {
 		t.Fatal("received blocks not recorded by the peer manager")
 	}
 	for _, p := range fpm.peers {
@@ -116,7 +116,7 @@ func TestSessionGetBlocks(t *testing.T) {
 	// look at new interactions with want manager
 
 	// should have cancelled each received block
-	if len(newCancelReqs) != activeWantsLimit {
+	if len(newCancelReqs) != broadcastLiveWantsLimit {
 		t.Fatal("did not cancel each block once it was received")
 	}
 	// new session reqs should be targeted
@@ -129,7 +129,7 @@ func TestSessionGetBlocks(t *testing.T) {
 	}
 
 	// full new round of cids should be requested
-	if totalEnqueued != activeWantsLimit {
+	if totalEnqueued != broadcastLiveWantsLimit {
 		t.Fatal("new blocks were not requested")
 	}
 
@@ -164,7 +164,7 @@ func TestSessionFindMorePeers(t *testing.T) {
 	session := New(ctx, id, fwm, fpm)
 	session.SetBaseTickDelay(200 * time.Microsecond)
 	blockGenerator := blocksutil.NewBlockGenerator()
-	blks := blockGenerator.Blocks(activeWantsLimit * 2)
+	blks := blockGenerator.Blocks(broadcastLiveWantsLimit * 2)
 	var cids []cid.Cid
 	for _, block := range blks {
 		cids = append(cids, block.Cid())
@@ -190,7 +190,7 @@ func TestSessionFindMorePeers(t *testing.T) {
 
 	// verify a broadcast was made
 	receivedWantReq := <-wantReqs
-	if len(receivedWantReq.cids) != activeWantsLimit {
+	if len(receivedWantReq.cids) != broadcastLiveWantsLimit {
 		t.Fatal("did not rebroadcast whole live list")
 	}
 	if receivedWantReq.peers != nil {

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -174,7 +174,7 @@ func TestSessionFindMorePeers(t *testing.T) {
 	wantReqs := make(chan wantReq, 1)
 	cancelReqs := make(chan wantReq, 1)
 	fwm := &fakeWantManager{wantReqs, cancelReqs}
-	fpm := &fakePeerManager{findMorePeersRequested: make(chan struct{})}
+	fpm := &fakePeerManager{findMorePeersRequested: make(chan struct{}, 1)}
 	frs := &fakeRequestSplitter{}
 	id := testutil.GenerateSessionID()
 	session := New(ctx, id, fwm, fpm, frs)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -97,8 +97,11 @@ func TestSessionGetBlocks(t *testing.T) {
 		receivedBlocks = append(receivedBlocks, receivedBlock)
 		cancelBlock := <-cancelReqs
 		newCancelReqs = append(newCancelReqs, cancelBlock)
-		wantBlock := <-wantReqs
-		newBlockReqs = append(newBlockReqs, wantBlock)
+		select {
+		case wantBlock := <-wantReqs:
+			newBlockReqs = append(newBlockReqs, wantBlock)
+		default:
+		}
 	}
 
 	// verify new peers were recorded
@@ -120,22 +123,22 @@ func TestSessionGetBlocks(t *testing.T) {
 		t.Fatal("did not cancel each block once it was received")
 	}
 	// new session reqs should be targeted
-	totalEnqueued := 0
+	var newCidsRequested []cid.Cid
 	for _, w := range newBlockReqs {
 		if len(w.peers) == 0 {
 			t.Fatal("should not have broadcast again after initial broadcast")
 		}
-		totalEnqueued += len(w.cids)
+		newCidsRequested = append(newCidsRequested, w.cids...)
 	}
 
 	// full new round of cids should be requested
-	if totalEnqueued != broadcastLiveWantsLimit {
+	if len(newCidsRequested) != broadcastLiveWantsLimit {
 		t.Fatal("new blocks were not requested")
 	}
 
 	// receive remaining blocks
 	for i, p := range peers {
-		session.ReceiveBlockFrom(p, blks[testutil.IndexOf(blks, newBlockReqs[i].cids[0])])
+		session.ReceiveBlockFrom(p, blks[testutil.IndexOf(blks, newCidsRequested[i])])
 		receivedBlock := <-getBlocksCh
 		receivedBlocks = append(receivedBlocks, receivedBlock)
 		cancelBlock := <-cancelReqs
@@ -190,7 +193,7 @@ func TestSessionFindMorePeers(t *testing.T) {
 
 	// verify a broadcast was made
 	receivedWantReq := <-wantReqs
-	if len(receivedWantReq.cids) != broadcastLiveWantsLimit {
+	if len(receivedWantReq.cids) < broadcastLiveWantsLimit {
 		t.Fatal("did not rebroadcast whole live list")
 	}
 	if receivedWantReq.peers != nil {

--- a/sessionmanager/sessionmanager.go
+++ b/sessionmanager/sessionmanager.go
@@ -23,10 +23,14 @@ type Session interface {
 type sesTrk struct {
 	session Session
 	pm      bssession.PeerManager
+	srs     bssession.RequestSplitter
 }
 
 // SessionFactory generates a new session for the SessionManager to track.
-type SessionFactory func(ctx context.Context, id uint64, pm bssession.PeerManager) Session
+type SessionFactory func(ctx context.Context, id uint64, pm bssession.PeerManager, srs bssession.RequestSplitter) Session
+
+// RequestSplitterFactory generates a new request splitter for a session.
+type RequestSplitterFactory func(ctx context.Context) bssession.RequestSplitter
 
 // PeerManagerFactory generates a new peer manager for a session.
 type PeerManagerFactory func(ctx context.Context, id uint64) bssession.PeerManager
@@ -34,9 +38,11 @@ type PeerManagerFactory func(ctx context.Context, id uint64) bssession.PeerManag
 // SessionManager is responsible for creating, managing, and dispatching to
 // sessions.
 type SessionManager struct {
-	ctx                context.Context
-	sessionFactory     SessionFactory
-	peerManagerFactory PeerManagerFactory
+	ctx                    context.Context
+	sessionFactory         SessionFactory
+	peerManagerFactory     PeerManagerFactory
+	requestSplitterFactory RequestSplitterFactory
+
 	// Sessions
 	sessLk   sync.Mutex
 	sessions []sesTrk
@@ -47,11 +53,12 @@ type SessionManager struct {
 }
 
 // New creates a new SessionManager.
-func New(ctx context.Context, sessionFactory SessionFactory, peerManagerFactory PeerManagerFactory) *SessionManager {
+func New(ctx context.Context, sessionFactory SessionFactory, peerManagerFactory PeerManagerFactory, requestSplitterFactory RequestSplitterFactory) *SessionManager {
 	return &SessionManager{
-		ctx:                ctx,
-		sessionFactory:     sessionFactory,
-		peerManagerFactory: peerManagerFactory,
+		ctx:                    ctx,
+		sessionFactory:         sessionFactory,
+		peerManagerFactory:     peerManagerFactory,
+		requestSplitterFactory: requestSplitterFactory,
 	}
 }
 
@@ -62,8 +69,9 @@ func (sm *SessionManager) NewSession(ctx context.Context) exchange.Fetcher {
 	sessionctx, cancel := context.WithCancel(ctx)
 
 	pm := sm.peerManagerFactory(sessionctx, id)
-	session := sm.sessionFactory(sessionctx, id, pm)
-	tracked := sesTrk{session, pm}
+	srs := sm.requestSplitterFactory(sessionctx)
+	session := sm.sessionFactory(sessionctx, id, pm, srs)
+	tracked := sesTrk{session, pm, srs}
 	sm.sessLk.Lock()
 	sm.sessions = append(sm.sessions, tracked)
 	sm.sessLk.Unlock()

--- a/sessionmanager/sessionmanager.go
+++ b/sessionmanager/sessionmanager.go
@@ -17,6 +17,7 @@ type Session interface {
 	exchange.Fetcher
 	InterestedIn(cid.Cid) bool
 	ReceiveBlockFrom(peer.ID, blocks.Block)
+	UpdateReceiveCounters(blocks.Block)
 }
 
 type sesTrk struct {
@@ -110,5 +111,16 @@ func (sm *SessionManager) ReceiveBlockFrom(from peer.ID, blk blocks.Block) {
 		if s.session.InterestedIn(k) {
 			s.session.ReceiveBlockFrom(from, blk)
 		}
+	}
+}
+
+// UpdateReceiveCounters records the fact that a block was received, allowing
+// sessions to track duplicates
+func (sm *SessionManager) UpdateReceiveCounters(blk blocks.Block) {
+	sm.sessLk.Lock()
+	defer sm.sessLk.Unlock()
+
+	for _, s := range sm.sessions {
+		s.session.UpdateReceiveCounters(blk)
 	}
 }

--- a/sessionmanager/sessionmanager_test.go
+++ b/sessionmanager/sessionmanager_test.go
@@ -13,10 +13,11 @@ import (
 )
 
 type fakeSession struct {
-	interested    bool
-	receivedBlock bool
-	id            uint64
-	pm            *fakePeerManager
+	interested            bool
+	receivedBlock         bool
+	updateReceiveCounters bool
+	id                    uint64
+	pm                    *fakePeerManager
 }
 
 func (*fakeSession) GetBlock(context.Context, cid.Cid) (blocks.Block, error) {
@@ -27,6 +28,7 @@ func (*fakeSession) GetBlocks(context.Context, []cid.Cid) (<-chan blocks.Block, 
 }
 func (fs *fakeSession) InterestedIn(cid.Cid) bool              { return fs.interested }
 func (fs *fakeSession) ReceiveBlockFrom(peer.ID, blocks.Block) { fs.receivedBlock = true }
+func (fs *fakeSession) UpdateReceiveCounters(blocks.Block)     { fs.updateReceiveCounters = true }
 
 type fakePeerManager struct {
 	id uint64

--- a/sessionpeermanager/sessionpeermanager.go
+++ b/sessionpeermanager/sessionpeermanager.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	maxOptimizedPeers = 25
+	maxOptimizedPeers = 32
 	reservePeers      = 2
 )
 

--- a/sessionpeermanager/sessionpeermanager.go
+++ b/sessionpeermanager/sessionpeermanager.go
@@ -134,6 +134,25 @@ func (spm *SessionPeerManager) insertOptimizedPeer(p peer.ID) {
 	spm.optimizedPeersArr = append([]peer.ID{p}, spm.optimizedPeersArr...)
 }
 
+func (spm *SessionPeerManager) removeOptimizedPeer(p peer.ID) {
+	for i := 0; i < len(spm.optimizedPeersArr); i++ {
+		if spm.optimizedPeersArr[i] == p {
+			spm.optimizedPeersArr = append(spm.optimizedPeersArr[:i], spm.optimizedPeersArr[i+1:]...)
+			return
+		}
+	}
+}
+
+func (spm *SessionPeerManager) removeUnoptimizedPeer(p peer.ID) {
+	for i := 0; i < len(spm.unoptimizedPeersArr); i++ {
+		if spm.unoptimizedPeersArr[i] == p {
+			spm.unoptimizedPeersArr[i] = spm.unoptimizedPeersArr[len(spm.unoptimizedPeersArr)-1]
+			spm.unoptimizedPeersArr = spm.unoptimizedPeersArr[:len(spm.unoptimizedPeersArr)-1]
+			return
+		}
+	}
+}
+
 type peerFoundMessage struct {
 	p peer.ID
 }
@@ -160,24 +179,10 @@ func (prm *peerResponseMessage) handle(spm *SessionPeerManager) {
 		spm.tagPeer(p)
 	} else {
 		if isOptimized {
-			if spm.optimizedPeersArr[0] == p {
-				return
-			}
-			for i := 0; i < len(spm.optimizedPeersArr); i++ {
-				if spm.optimizedPeersArr[i] == p {
-					spm.optimizedPeersArr = append(spm.optimizedPeersArr[:i], spm.optimizedPeersArr[i+1:]...)
-					break
-				}
-			}
+			spm.removeOptimizedPeer(p)
 		} else {
 			spm.activePeers[p] = true
-			for i := 0; i < len(spm.unoptimizedPeersArr); i++ {
-				if spm.unoptimizedPeersArr[i] == p {
-					spm.unoptimizedPeersArr[i] = spm.unoptimizedPeersArr[len(spm.unoptimizedPeersArr)-1]
-					spm.unoptimizedPeersArr = spm.unoptimizedPeersArr[:len(spm.unoptimizedPeersArr)-1]
-					break
-				}
-			}
+			spm.removeUnoptimizedPeer(p)
 		}
 	}
 	spm.insertOptimizedPeer(p)

--- a/sessionrequestsplitter/sessionrequestsplitter.go
+++ b/sessionrequestsplitter/sessionrequestsplitter.go
@@ -1,0 +1,163 @@
+package sessionrequestsplitter
+
+import (
+	"context"
+
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-peer"
+)
+
+const (
+	minReceivedToAdjustSplit = 2
+	maxSplit                 = 16
+	maxAcceptableDupes       = 0.4
+	minDuplesToTryLessSplits = 0.2
+	initialSplit             = 2
+)
+
+// PartialRequest is represents one slice of an over request split among peers
+type PartialRequest struct {
+	Peers []peer.ID
+	Keys  []cid.Cid
+}
+
+type srsMessage interface {
+	handle(srs *SessionRequestSplitter)
+}
+
+// SessionRequestSplitter track how many duplicate and unique blocks come in and
+// uses that to determine how much to split up each set of wants among peers.
+type SessionRequestSplitter struct {
+	ctx      context.Context
+	messages chan srsMessage
+
+	// data, do not touch outside run loop
+	receivedCount          int
+	split                  int
+	duplicateReceivedCount int
+}
+
+// New returns a new SessionRequestSplitter.
+func New(ctx context.Context) *SessionRequestSplitter {
+	srs := &SessionRequestSplitter{
+		ctx:      ctx,
+		messages: make(chan srsMessage, 10),
+		split:    initialSplit,
+	}
+	go srs.run()
+	return srs
+}
+
+// SplitRequest splits a request for the given cids one or more times among the
+// given peers.
+func (srs *SessionRequestSplitter) SplitRequest(peers []peer.ID, ks []cid.Cid) []*PartialRequest {
+	resp := make(chan []*PartialRequest)
+
+	select {
+	case srs.messages <- &splitRequestMessage{peers, ks, resp}:
+	case <-srs.ctx.Done():
+		return nil
+	}
+	select {
+	case splitRequests := <-resp:
+		return splitRequests
+	case <-srs.ctx.Done():
+		return nil
+	}
+
+}
+
+// RecordDuplicateBlock records the fact that the session received a duplicate
+// block and adjusts split factor as neccesary.
+func (srs *SessionRequestSplitter) RecordDuplicateBlock() {
+	select {
+	case srs.messages <- &recordDuplicateMessage{}:
+	case <-srs.ctx.Done():
+	}
+}
+
+// RecordUniqueBlock records the fact that the session received unique block
+// and adjusts the split factor as neccesary.
+func (srs *SessionRequestSplitter) RecordUniqueBlock() {
+	select {
+	case srs.messages <- &recordUniqueMessage{}:
+	case <-srs.ctx.Done():
+	}
+}
+
+func (srs *SessionRequestSplitter) run() {
+	for {
+		select {
+		case message := <-srs.messages:
+			message.handle(srs)
+		case <-srs.ctx.Done():
+			return
+		}
+	}
+}
+
+func (srs *SessionRequestSplitter) duplicateRatio() float64 {
+	return float64(srs.duplicateReceivedCount) / float64(srs.receivedCount)
+}
+
+type splitRequestMessage struct {
+	peers []peer.ID
+	ks    []cid.Cid
+	resp  chan []*PartialRequest
+}
+
+func (s *splitRequestMessage) handle(srs *SessionRequestSplitter) {
+	split := srs.split
+	peers := s.peers
+	ks := s.ks
+	if len(peers) < split {
+		split = len(peers)
+	}
+	peerSplits := splitPeers(peers, split)
+	if len(ks) < split {
+		split = len(ks)
+	}
+	keySplits := splitKeys(ks, split)
+	splitRequests := make([]*PartialRequest, len(keySplits))
+	for i := range splitRequests {
+		splitRequests[i] = &PartialRequest{peerSplits[i], keySplits[i]}
+	}
+	s.resp <- splitRequests
+}
+
+type recordDuplicateMessage struct{}
+
+func (r *recordDuplicateMessage) handle(srs *SessionRequestSplitter) {
+	srs.receivedCount++
+	srs.duplicateReceivedCount++
+	if (srs.receivedCount > minReceivedToAdjustSplit) && (srs.duplicateRatio() > maxAcceptableDupes) && (srs.split < maxSplit) {
+		srs.split++
+	}
+}
+
+type recordUniqueMessage struct{}
+
+func (r *recordUniqueMessage) handle(srs *SessionRequestSplitter) {
+	srs.receivedCount++
+	if (srs.split > 1) && (srs.duplicateRatio() < minDuplesToTryLessSplits) {
+		srs.split--
+	}
+
+}
+func splitKeys(ks []cid.Cid, split int) [][]cid.Cid {
+	splits := make([][]cid.Cid, split)
+	for i, c := range ks {
+		pos := i % split
+		splits[pos] = append(splits[pos], c)
+	}
+	return splits
+}
+
+func splitPeers(peers []peer.ID, split int) [][]peer.ID {
+	splits := make([][]peer.ID, split)
+	for i, p := range peers {
+		pos := i % split
+		splits[pos] = append(splits[pos], p)
+	}
+	return splits
+}

--- a/sessionrequestsplitter/sessionrequestsplitter_test.go
+++ b/sessionrequestsplitter/sessionrequestsplitter_test.go
@@ -1,0 +1,96 @@
+package sessionrequestsplitter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/go-bitswap/testutil"
+)
+
+func TestSplittingRequests(t *testing.T) {
+	ctx := context.Background()
+	peers := testutil.GeneratePeers(10)
+	keys := testutil.GenerateCids(6)
+
+	srs := New(ctx)
+
+	partialRequests := srs.SplitRequest(peers, keys)
+	if len(partialRequests) != 2 {
+		t.Fatal("Did not generate right number of partial requests")
+	}
+	for _, partialRequest := range partialRequests {
+		if len(partialRequest.Peers) != 5 && len(partialRequest.Keys) != 3 {
+			t.Fatal("Did not split request into even partial requests")
+		}
+	}
+}
+
+func TestSplittingRequestsTooFewKeys(t *testing.T) {
+	ctx := context.Background()
+	peers := testutil.GeneratePeers(10)
+	keys := testutil.GenerateCids(1)
+
+	srs := New(ctx)
+
+	partialRequests := srs.SplitRequest(peers, keys)
+	if len(partialRequests) != 1 {
+		t.Fatal("Should only generate as many requests as keys")
+	}
+	for _, partialRequest := range partialRequests {
+		if len(partialRequest.Peers) != 5 && len(partialRequest.Keys) != 1 {
+			t.Fatal("Should still split peers up between keys")
+		}
+	}
+}
+
+func TestSplittingRequestsTooFewPeers(t *testing.T) {
+	ctx := context.Background()
+	peers := testutil.GeneratePeers(1)
+	keys := testutil.GenerateCids(6)
+
+	srs := New(ctx)
+
+	partialRequests := srs.SplitRequest(peers, keys)
+	if len(partialRequests) != 1 {
+		t.Fatal("Should only generate as many requests as peers")
+	}
+	for _, partialRequest := range partialRequests {
+		if len(partialRequest.Peers) != 1 && len(partialRequest.Keys) != 6 {
+			t.Fatal("Should not split keys if there are not enough peers")
+		}
+	}
+}
+
+func TestSplittingRequestsIncreasingSplitDueToDupes(t *testing.T) {
+	ctx := context.Background()
+	peers := testutil.GeneratePeers(maxSplit)
+	keys := testutil.GenerateCids(maxSplit)
+
+	srs := New(ctx)
+
+	for i := 0; i < maxSplit+minReceivedToAdjustSplit; i++ {
+		srs.RecordDuplicateBlock()
+	}
+
+	partialRequests := srs.SplitRequest(peers, keys)
+	if len(partialRequests) != maxSplit {
+		t.Fatal("Did not adjust split up as duplicates came in")
+	}
+}
+
+func TestSplittingRequestsDecreasingSplitDueToNoDupes(t *testing.T) {
+	ctx := context.Background()
+	peers := testutil.GeneratePeers(maxSplit)
+	keys := testutil.GenerateCids(maxSplit)
+
+	srs := New(ctx)
+
+	for i := 0; i < 5+minReceivedToAdjustSplit; i++ {
+		srs.RecordUniqueBlock()
+	}
+
+	partialRequests := srs.SplitRequest(peers, keys)
+	if len(partialRequests) != 1 {
+		t.Fatal("Did not adjust split down as unique blocks came in")
+	}
+}


### PR DESCRIPTION
# Goals

This is an initial PR to speed up sessions and reduce dupes. It is not the ONLY improvement I'm working on, but it makes significant progress. It matches Jeremy's PR on benchmarks for dupes (for the most part), but matches master on speed (for the most part). In addition, it shows impressive results with `LS` on Wikipedia. See results in comments.

# Implementation

This PR has basically 3 improvements:

1. The session peer manager is just SLIGHTLY smarter in that:
   a. It returns a maximum of 32 peers (why would you ever need to ask more at once?)
   b. It somewhat prioritizes the best peers. The strategy is simply if you receive a block from a peer first, you assume that's a good peer and put it at the front of the list for peers on your next want request. This is not ordering peers by latency, it's just assuming whoever responds is a good person to ask next.

2. The split broadcast vs target max want list for sessions from jeremy's code is copied over. Basically, this is just the assumption that you broadcast only 4 wants at once (previously 16), but once you have peers, you go up to 32 on targeted requests

3. Requests for a series of blocks are split among peers, similarly to Jeremy's PR. However, where Jeremy's PR kept the splitting right in the Session, this moves the splitting out to a separate SessionRequestSplitter module. The strategy pursued is slightly different, and is simply attempting to minimize dupes w/o slowing down the overall request speed by:
   a. If dupes go above a certain threshold, increase the split factor
   b. If they fall below a certain threshold, decrease the split factor (to increase speed, just in case)
Honestly, there are a lot of better ways to do this, but this is functional and works well. (though it vacillates between extremes, cause there's minimal throttling of these adjustments)
   c. To make this work, dupes are now tracked on a per session basis (and we keep a list of past wants to know what's a dupe)

# Next

Once this PR is merged, there are three further optimizations:
1. Peer optimization should be tracked more closely by monitoring actual latency on requests
2. Request splitting should be more intelligent about reducing dupes, and throttled on its adjustments, and possibly become more "fine-grained" (as in fewer adjustments, or smaller adjustments) as a session is open longer, cause at that point, you know more about what the network looks like for whatever it is you're requesting.
3. Request splitting should also take into account how many requests a given node has at once -- that way we don't overload the pipe on a given peer. This first needs: https://github.com/ipfs/go-bitswap/issues/40

# For discussion

This is not a "end goal" PR for session speedup, but a first step and a framework for further optimizations (basically, improvements to the peer manager and the request splitter can proceed independently). I actually have progress on some of the above next steps, but I feel like that should be in a separate PR, so the number of changes aren't overwhelming, and also, I want to make sure this approach feels ok to people.

This also includes some minor changes to the benchmarks, primarily to put the saved json file in a folder that isn't included in git commits.