### PR TITLE
Bitswap Refactor #2: Extract PeerManager From Want Manager + Unit Test

### DIFF
--- a/bitswap_test.go
+++ b/bitswap_test.go
@@ -202,10 +202,10 @@ func PerformDistributionTest(t *testing.T, numInstances, numBlocks int) {
 	nump := len(instances) - 1
 	// assert we're properly connected
 	for _, inst := range instances {
-		peers := inst.Exchange.wm.ConnectedPeers()
+		peers := inst.Exchange.pm.ConnectedPeers()
 		for i := 0; i < 10 && len(peers) != nump; i++ {
 			time.Sleep(time.Millisecond * 50)
-			peers = inst.Exchange.wm.ConnectedPeers()
+			peers = inst.Exchange.pm.ConnectedPeers()
 		}
 		if len(peers) != nump {
 			t.Fatal("not enough peers connected to instance")

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -14,11 +14,14 @@ import (
 
 var log = logging.Logger("bitswap")
 
+// MessageNetwork is any network that can connect peers and generate a message
+// sender
 type MessageNetwork interface {
 	ConnectTo(context.Context, peer.ID) error
 	NewMessageSender(context.Context, peer.ID) (bsnet.MessageSender, error)
 }
 
+// MessageQueue implements queuee of want messages to send to peers
 type MessageQueue struct {
 	p peer.ID
 
@@ -35,6 +38,7 @@ type MessageQueue struct {
 	done chan struct{}
 }
 
+// New creats a new MessageQueues
 func New(p peer.ID, network MessageNetwork) *MessageQueue {
 	return &MessageQueue{
 		done:    make(chan struct{}),
@@ -46,52 +50,31 @@ func New(p peer.ID, network MessageNetwork) *MessageQueue {
 	}
 }
 
+// RefIncrement increments the refcount for a message queue
 func (mq *MessageQueue) RefIncrement() {
 	mq.refcnt++
 }
 
+// RefDecrement decrements the refcount for a message queue and returns true
+// if the refcount is now 0
 func (mq *MessageQueue) RefDecrement() bool {
 	mq.refcnt--
 	return mq.refcnt > 0
 }
 
+// AddMessage adds new entries to an outgoing message for a given session
 func (mq *MessageQueue) AddMessage(entries []*bsmsg.Entry, ses uint64) {
-	var work bool
-	mq.outlk.Lock()
-	defer func() {
-		mq.outlk.Unlock()
-		if !work {
-			return
-		}
-		select {
-		case mq.work <- struct{}{}:
-		default:
-		}
-	}()
-
-	// if we have no message held allocate a new one
-	if mq.out == nil {
-		mq.out = bsmsg.New(false)
+	if !mq.addEntries(entries, ses) {
+		return
 	}
-
-	// TODO: add a msg.Combine(...) method
-	// otherwise, combine the one we are holding with the
-	// one passed in
-	for _, e := range entries {
-		if e.Cancel {
-			if mq.wl.Remove(e.Cid, ses) {
-				work = true
-				mq.out.Cancel(e.Cid)
-			}
-		} else {
-			if mq.wl.Add(e.Cid, e.Priority, ses) {
-				work = true
-				mq.out.AddEntry(e.Cid, e.Priority)
-			}
-		}
+	select {
+	case mq.work <- struct{}{}:
+	default:
 	}
 }
 
+// Startup starts the processing of messages, and creates an initial message
+// based on the given initial wantlist
 func (mq *MessageQueue) Startup(ctx context.Context, initialEntries []*wantlist.Entry) {
 
 	// new peer, we will want to give them our full wantlist
@@ -110,6 +93,7 @@ func (mq *MessageQueue) Startup(ctx context.Context, initialEntries []*wantlist.
 
 }
 
+// Shutdown stops the processing of messages for a message queue
 func (mq *MessageQueue) Shutdown() {
 	close(mq.done)
 }
@@ -133,84 +117,134 @@ func (mq *MessageQueue) runQueue(ctx context.Context) {
 	}
 }
 
-func (mq *MessageQueue) doWork(ctx context.Context) {
-	// grab outgoing message
+func (mq *MessageQueue) addEntries(entries []*bsmsg.Entry, ses uint64) bool {
+	var work bool
 	mq.outlk.Lock()
-	wlm := mq.out
+	defer mq.outlk.Unlock()
+	// if we have no message held allocate a new one
+	if mq.out == nil {
+		mq.out = bsmsg.New(false)
+	}
+
+	// TODO: add a msg.Combine(...) method
+	// otherwise, combine the one we are holding with the
+	// one passed in
+	for _, e := range entries {
+		if e.Cancel {
+			if mq.wl.Remove(e.Cid, ses) {
+				work = true
+				mq.out.Cancel(e.Cid)
+			}
+		} else {
+			if mq.wl.Add(e.Cid, e.Priority, ses) {
+				work = true
+				mq.out.AddEntry(e.Cid, e.Priority)
+			}
+		}
+	}
+
+	return work
+}
+
+func (mq *MessageQueue) doWork(ctx context.Context) {
+
+	wlm := mq.extractOutgoingMessage()
 	if wlm == nil || wlm.Empty() {
-		mq.outlk.Unlock()
 		return
 	}
-	mq.out = nil
-	mq.outlk.Unlock()
 
 	// NB: only open a stream if we actually have data to send
-	if mq.sender == nil {
-		err := mq.openSender(ctx)
-		if err != nil {
-			log.Infof("cant open message sender to peer %s: %s", mq.p, err)
-			// TODO: cant connect, what now?
-			return
-		}
+	err := mq.initializeSender(ctx)
+	if err != nil {
+		log.Infof("cant open message sender to peer %s: %s", mq.p, err)
+		// TODO: cant connect, what now?
+		return
 	}
 
 	// send wantlist updates
 	for { // try to send this message until we fail.
-		err := mq.sender.SendMsg(ctx, wlm)
-		if err == nil {
+		if mq.attemptSendAndRecovery(ctx, wlm) {
 			return
 		}
-
-		log.Infof("bitswap send error: %s", err)
-		mq.sender.Reset()
-		mq.sender = nil
-
-		select {
-		case <-mq.done:
-			return
-		case <-ctx.Done():
-			return
-		case <-time.After(time.Millisecond * 100):
-			// wait 100ms in case disconnect notifications are still propogating
-			log.Warning("SendMsg errored but neither 'done' nor context.Done() were set")
-		}
-
-		err = mq.openSender(ctx)
-		if err != nil {
-			log.Infof("couldnt open sender again after SendMsg(%s) failed: %s", mq.p, err)
-			// TODO(why): what do we do now?
-			// I think the *right* answer is to probably put the message we're
-			// trying to send back, and then return to waiting for new work or
-			// a disconnect.
-			return
-		}
-
-		// TODO: Is this the same instance for the remote peer?
-		// If its not, we should resend our entire wantlist to them
-		/*
-			if mq.sender.InstanceID() != mq.lastSeenInstanceID {
-				wlm = mq.getFullWantlistMessage()
-			}
-		*/
 	}
 }
 
-func (mq *MessageQueue) openSender(ctx context.Context) error {
+func (mq *MessageQueue) initializeSender(ctx context.Context) error {
+	if mq.sender != nil {
+		return nil
+	}
+	nsender, err := openSender(ctx, mq.network, mq.p)
+	if err != nil {
+		return err
+	}
+	mq.sender = nsender
+	return nil
+}
+
+func (mq *MessageQueue) attemptSendAndRecovery(ctx context.Context, wlm bsmsg.BitSwapMessage) bool {
+	err := mq.sender.SendMsg(ctx, wlm)
+	if err == nil {
+		return true
+	}
+
+	log.Infof("bitswap send error: %s", err)
+	mq.sender.Reset()
+	mq.sender = nil
+
+	select {
+	case <-mq.done:
+		return true
+	case <-ctx.Done():
+		return true
+	case <-time.After(time.Millisecond * 100):
+		// wait 100ms in case disconnect notifications are still propogating
+		log.Warning("SendMsg errored but neither 'done' nor context.Done() were set")
+	}
+
+	err = mq.initializeSender(ctx)
+	if err != nil {
+		log.Infof("couldnt open sender again after SendMsg(%s) failed: %s", mq.p, err)
+		// TODO(why): what do we do now?
+		// I think the *right* answer is to probably put the message we're
+		// trying to send back, and then return to waiting for new work or
+		// a disconnect.
+		return true
+	}
+
+	// TODO: Is this the same instance for the remote peer?
+	// If its not, we should resend our entire wantlist to them
+	/*
+		if mq.sender.InstanceID() != mq.lastSeenInstanceID {
+			wlm = mq.getFullWantlistMessage()
+		}
+	*/
+	return false
+}
+
+func (mq *MessageQueue) extractOutgoingMessage() bsmsg.BitSwapMessage {
+	// grab outgoing message
+	mq.outlk.Lock()
+	wlm := mq.out
+	mq.out = nil
+	mq.outlk.Unlock()
+	return wlm
+}
+
+func openSender(ctx context.Context, network MessageNetwork, p peer.ID) (bsnet.MessageSender, error) {
 	// allow ten minutes for connections this includes looking them up in the
 	// dht dialing them, and handshaking
 	conctx, cancel := context.WithTimeout(ctx, time.Minute*10)
 	defer cancel()
 
-	err := mq.network.ConnectTo(conctx, mq.p)
+	err := network.ConnectTo(conctx, p)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	nsender, err := mq.network.NewMessageSender(ctx, mq.p)
+	nsender, err := network.NewMessageSender(ctx, p)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	mq.sender = nsender
-	return nil
+	return nsender, nil
 }

--- a/messagequeue/messagequeue_test.go
+++ b/messagequeue/messagequeue_test.go
@@ -1,0 +1,161 @@
+package messagequeue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-bitswap/testutil"
+
+	bsmsg "github.com/ipfs/go-bitswap/message"
+	bsnet "github.com/ipfs/go-bitswap/network"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+type fakeMessageNetwork struct {
+	connectError       error
+	messageSenderError error
+	messageSender      bsnet.MessageSender
+}
+
+func (fmn *fakeMessageNetwork) ConnectTo(context.Context, peer.ID) error {
+	return fmn.connectError
+}
+
+func (fmn *fakeMessageNetwork) NewMessageSender(context.Context, peer.ID) (bsnet.MessageSender, error) {
+	if fmn.messageSenderError == nil {
+		return fmn.messageSender, nil
+	} else {
+		return nil, fmn.messageSenderError
+	}
+}
+
+type fakeMessageSender struct {
+	sendError    error
+	fullClosed   chan<- struct{}
+	reset        chan<- struct{}
+	messagesSent chan<- bsmsg.BitSwapMessage
+}
+
+func (fms *fakeMessageSender) SendMsg(ctx context.Context, msg bsmsg.BitSwapMessage) error {
+	fms.messagesSent <- msg
+	return fms.sendError
+}
+func (fms *fakeMessageSender) Close() error { fms.fullClosed <- struct{}{}; return nil }
+func (fms *fakeMessageSender) Reset() error { fms.reset <- struct{}{}; return nil }
+
+func collectMessages(ctx context.Context,
+	t *testing.T,
+	messagesSent <-chan bsmsg.BitSwapMessage,
+	timeout time.Duration) []bsmsg.BitSwapMessage {
+	var messagesReceived []bsmsg.BitSwapMessage
+	timeoutctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for {
+		select {
+		case messageReceived := <-messagesSent:
+			messagesReceived = append(messagesReceived, messageReceived)
+		case <-timeoutctx.Done():
+			return messagesReceived
+		}
+	}
+}
+
+func totalEntriesLength(messages []bsmsg.BitSwapMessage) int {
+	totalLength := 0
+	for _, messages := range messages {
+		totalLength += len(messages.Wantlist())
+	}
+	return totalLength
+}
+
+func TestStartupAndShutdown(t *testing.T) {
+	ctx := context.Background()
+	messagesSent := make(chan bsmsg.BitSwapMessage)
+	resetChan := make(chan struct{}, 1)
+	fullClosedChan := make(chan struct{}, 1)
+	fakeSender := &fakeMessageSender{nil, fullClosedChan, resetChan, messagesSent}
+	fakenet := &fakeMessageNetwork{nil, nil, fakeSender}
+	peerID := testutil.GeneratePeers(1)[0]
+	messageQueue := New(peerID, fakenet)
+	ses := testutil.GenerateSessionID()
+	wl := testutil.GenerateWantlist(10, ses)
+
+	messageQueue.Startup(ctx, wl.Entries())
+
+	messages := collectMessages(ctx, t, messagesSent, 10*time.Millisecond)
+	if len(messages) != 1 {
+		t.Fatal("wrong number of messages were sent for initial wants")
+	}
+
+	firstMessage := messages[0]
+	if len(firstMessage.Wantlist()) != wl.Len() {
+		t.Fatal("did not add all wants to want list")
+	}
+	for _, entry := range firstMessage.Wantlist() {
+		if entry.Cancel {
+			t.Fatal("initial add sent cancel entry when it should not have")
+		}
+	}
+
+	messageQueue.Shutdown()
+
+	timeoutctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	defer cancel()
+	select {
+	case <-fullClosedChan:
+	case <-resetChan:
+		t.Fatal("message sender should have been closed but was reset")
+	case <-timeoutctx.Done():
+		t.Fatal("message sender should have been closed but wasn't")
+	}
+}
+
+func TestSendingMessagesDeduped(t *testing.T) {
+	ctx := context.Background()
+	messagesSent := make(chan bsmsg.BitSwapMessage)
+	resetChan := make(chan struct{}, 1)
+	fullClosedChan := make(chan struct{}, 1)
+	fakeSender := &fakeMessageSender{nil, fullClosedChan, resetChan, messagesSent}
+	fakenet := &fakeMessageNetwork{nil, nil, fakeSender}
+	peerID := testutil.GeneratePeers(1)[0]
+	messageQueue := New(peerID, fakenet)
+	ses1 := testutil.GenerateSessionID()
+	ses2 := testutil.GenerateSessionID()
+	entries := testutil.GenerateMessageEntries(10, false)
+	messageQueue.Startup(ctx, nil)
+
+	messageQueue.AddMessage(entries, ses1)
+	messageQueue.AddMessage(entries, ses2)
+	messages := collectMessages(ctx, t, messagesSent, 10*time.Millisecond)
+
+	if totalEntriesLength(messages) != len(entries) {
+		t.Fatal("Messages were not deduped")
+	}
+}
+
+func TestSendingMessagesPartialDupe(t *testing.T) {
+	ctx := context.Background()
+	messagesSent := make(chan bsmsg.BitSwapMessage)
+	resetChan := make(chan struct{}, 1)
+	fullClosedChan := make(chan struct{}, 1)
+	fakeSender := &fakeMessageSender{nil, fullClosedChan, resetChan, messagesSent}
+	fakenet := &fakeMessageNetwork{nil, nil, fakeSender}
+	peerID := testutil.GeneratePeers(1)[0]
+	messageQueue := New(peerID, fakenet)
+	ses1 := testutil.GenerateSessionID()
+	ses2 := testutil.GenerateSessionID()
+	entries := testutil.GenerateMessageEntries(10, false)
+	moreEntries := testutil.GenerateMessageEntries(5, false)
+	secondEntries := append(entries[5:], moreEntries...)
+	messageQueue.Startup(ctx, nil)
+
+	messageQueue.AddMessage(entries, ses1)
+	messageQueue.AddMessage(secondEntries, ses2)
+	messages := collectMessages(ctx, t, messagesSent, 20*time.Millisecond)
+
+	if totalEntriesLength(messages) != len(entries)+len(moreEntries) {
+		t.Fatal("messages were not correctly deduped")
+	}
+
+}

--- a/peermanager/peermanager.go
+++ b/peermanager/peermanager.go
@@ -1,0 +1,192 @@
+package peermanager
+
+import (
+	"context"
+
+	bsmsg "github.com/ipfs/go-bitswap/message"
+	wantlist "github.com/ipfs/go-bitswap/wantlist"
+	logging "github.com/ipfs/go-log"
+
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+var log = logging.Logger("bitswap")
+
+var (
+	metricsBuckets = []float64{1 << 6, 1 << 10, 1 << 14, 1 << 18, 1<<18 + 15, 1 << 22}
+)
+
+type sendMessageParams struct {
+	entries []*bsmsg.Entry
+	targets []peer.ID
+	from    uint64
+}
+
+type connectParams struct {
+	peer           peer.ID
+	initialEntries []*wantlist.Entry
+}
+
+type peerMessageType int
+
+const (
+	connect peerMessageType = iota + 1
+	disconnect
+	getPeers
+	sendMessage
+)
+
+type peerMessage struct {
+	messageType peerMessageType
+	params      interface{}
+	resultsChan chan interface{}
+}
+
+type PeerQueue interface {
+	RefIncrement()
+	RefDecrement() bool
+	AddMessage(entries []*bsmsg.Entry, ses uint64)
+	Startup(ctx context.Context, initialEntries []*wantlist.Entry)
+	Shutdown()
+}
+
+type PeerQueueFactory func(p peer.ID) PeerQueue
+
+type PeerManager struct {
+	// sync channel for Run loop
+	peerMessages chan peerMessage
+
+	// synchronized by Run loop, only touch inside there
+	peerQueues map[peer.ID]PeerQueue
+
+	createPeerQueue PeerQueueFactory
+	ctx             context.Context
+	cancel          func()
+}
+
+func New(ctx context.Context, createPeerQueue PeerQueueFactory) *PeerManager {
+	ctx, cancel := context.WithCancel(ctx)
+	return &PeerManager{
+		peerMessages:    make(chan peerMessage, 10),
+		peerQueues:      make(map[peer.ID]PeerQueue),
+		createPeerQueue: createPeerQueue,
+		ctx:             ctx,
+		cancel:          cancel,
+	}
+}
+
+func (pm *PeerManager) ConnectedPeers() []peer.ID {
+	resp := make(chan interface{})
+	pm.peerMessages <- peerMessage{getPeers, nil, resp}
+	peers := <-resp
+	return peers.([]peer.ID)
+}
+
+func (pm *PeerManager) startPeerHandler(p peer.ID, initialEntries []*wantlist.Entry) PeerQueue {
+	mq, ok := pm.peerQueues[p]
+	if ok {
+		mq.RefIncrement()
+		return nil
+	}
+
+	mq = pm.createPeerQueue(p)
+	pm.peerQueues[p] = mq
+	mq.Startup(pm.ctx, initialEntries)
+	return mq
+}
+
+func (pm *PeerManager) stopPeerHandler(p peer.ID) {
+	pq, ok := pm.peerQueues[p]
+	if !ok {
+		// TODO: log error?
+		return
+	}
+
+	if pq.RefDecrement() {
+		return
+	}
+
+	pq.Shutdown()
+	delete(pm.peerQueues, p)
+}
+
+func (pm *PeerManager) Connected(p peer.ID, initialEntries []*wantlist.Entry) {
+	select {
+	case pm.peerMessages <- peerMessage{connect, connectParams{peer: p, initialEntries: initialEntries}, nil}:
+	case <-pm.ctx.Done():
+	}
+}
+
+func (pm *PeerManager) Disconnected(p peer.ID) {
+	select {
+	case pm.peerMessages <- peerMessage{disconnect, p, nil}:
+	case <-pm.ctx.Done():
+	}
+}
+
+func (pm *PeerManager) SendMessage(entries []*bsmsg.Entry, targets []peer.ID, from uint64) {
+	select {
+	case pm.peerMessages <- peerMessage{
+		sendMessage,
+		&sendMessageParams{entries: entries, targets: targets, from: from},
+		nil,
+	}:
+	case <-pm.ctx.Done():
+	}
+}
+
+func (pm *PeerManager) Startup() {
+	go pm.run()
+}
+
+func (pm *PeerManager) Shutdown() {
+	pm.cancel()
+}
+
+// TODO: use goprocess here once i trust it
+func (pm *PeerManager) run() {
+	// NOTE: Do not open any streams or connections from anywhere in this
+	// event loop. Really, just don't do anything likely to block.
+	for {
+		select {
+		case message := <-pm.peerMessages:
+			pm.handleMessage(message)
+		case <-pm.ctx.Done():
+			return
+		}
+	}
+}
+
+func (pm *PeerManager) handleMessage(message peerMessage) {
+
+	switch message.messageType {
+	case sendMessage:
+		ms := message.params.(*sendMessageParams)
+		if len(ms.targets) == 0 {
+			for _, p := range pm.peerQueues {
+				p.AddMessage(ms.entries, ms.from)
+			}
+		} else {
+			for _, t := range ms.targets {
+				p, ok := pm.peerQueues[t]
+				if !ok {
+					log.Infof("tried sending wantlist change to non-partner peer: %s", t)
+					continue
+				}
+				p.AddMessage(ms.entries, ms.from)
+			}
+		}
+	case connect:
+		p := message.params.(connectParams)
+		pm.startPeerHandler(p.peer, p.initialEntries)
+	case disconnect:
+		disconnectPeer := message.params.(peer.ID)
+		pm.stopPeerHandler(disconnectPeer)
+	case getPeers:
+		peers := make([]peer.ID, 0, len(pm.peerQueues))
+		for p := range pm.peerQueues {
+			peers = append(peers, p)
+		}
+		message.resultsChan <- peers
+	}
+}

--- a/peermanager/peermanager.go
+++ b/peermanager/peermanager.go
@@ -16,32 +16,7 @@ var (
 	metricsBuckets = []float64{1 << 6, 1 << 10, 1 << 14, 1 << 18, 1<<18 + 15, 1 << 22}
 )
 
-type sendMessageParams struct {
-	entries []*bsmsg.Entry
-	targets []peer.ID
-	from    uint64
-}
-
-type connectParams struct {
-	peer           peer.ID
-	initialEntries []*wantlist.Entry
-}
-
-type peerMessageType int
-
-const (
-	connect peerMessageType = iota + 1
-	disconnect
-	getPeers
-	sendMessage
-)
-
-type peerMessage struct {
-	messageType peerMessageType
-	params      interface{}
-	resultsChan chan interface{}
-}
-
+// PeerQueue provides a queer of messages to be sent for a single peer
 type PeerQueue interface {
 	RefIncrement()
 	RefDecrement() bool
@@ -50,8 +25,14 @@ type PeerQueue interface {
 	Shutdown()
 }
 
+// PeerQueueFactory provides a function that will create a PeerQueue
 type PeerQueueFactory func(p peer.ID) PeerQueue
 
+type peerMessage interface {
+	handle(pm *PeerManager)
+}
+
+// PeerManager manages a pool of peers and sends messages to peers in the pool
 type PeerManager struct {
 	// sync channel for Run loop
 	peerMessages chan peerMessage
@@ -64,6 +45,7 @@ type PeerManager struct {
 	cancel          func()
 }
 
+// New creates a new PeerManager, given a context and a peerQueueFactory
 func New(ctx context.Context, createPeerQueue PeerQueueFactory) *PeerManager {
 	ctx, cancel := context.WithCancel(ctx)
 	return &PeerManager{
@@ -75,11 +57,102 @@ func New(ctx context.Context, createPeerQueue PeerQueueFactory) *PeerManager {
 	}
 }
 
+// ConnectedPeers returns a list of peers this PeerManager is managing
 func (pm *PeerManager) ConnectedPeers() []peer.ID {
-	resp := make(chan interface{})
-	pm.peerMessages <- peerMessage{getPeers, nil, resp}
-	peers := <-resp
-	return peers.([]peer.ID)
+	resp := make(chan []peer.ID)
+	pm.peerMessages <- &getPeersMessage{resp}
+	return <-resp
+}
+
+// Connected is called to add a new peer to the pool, and send it an initial set
+// of wants
+func (pm *PeerManager) Connected(p peer.ID, initialEntries []*wantlist.Entry) {
+	select {
+	case pm.peerMessages <- &connectPeerMessage{p, initialEntries}:
+	case <-pm.ctx.Done():
+	}
+}
+
+// Disconnected is called to remove a peer from the pool
+func (pm *PeerManager) Disconnected(p peer.ID) {
+	select {
+	case pm.peerMessages <- &disconnectPeerMessage{p}:
+	case <-pm.ctx.Done():
+	}
+}
+
+// SendMessage is called to send a message to all or some peers in the pool
+// if targets is nil, it sends to all
+func (pm *PeerManager) SendMessage(entries []*bsmsg.Entry, targets []peer.ID, from uint64) {
+	select {
+	case pm.peerMessages <- &sendPeerMessage{entries: entries, targets: targets, from: from}:
+	case <-pm.ctx.Done():
+	}
+}
+
+// Startup enables the run loop for the PeerManager - no processing will occur
+// if startup is not called
+func (pm *PeerManager) Startup() {
+	go pm.run()
+}
+
+// Shutdown shutsdown processing for the PeerManager
+func (pm *PeerManager) Shutdown() {
+	pm.cancel()
+}
+
+func (pm *PeerManager) run() {
+	for {
+		select {
+		case message := <-pm.peerMessages:
+			message.handle(pm)
+		case <-pm.ctx.Done():
+			return
+		}
+	}
+}
+
+type sendPeerMessage struct {
+	entries []*bsmsg.Entry
+	targets []peer.ID
+	from    uint64
+}
+
+func (s *sendPeerMessage) handle(pm *PeerManager) {
+	pm.sendMessage(s)
+}
+
+type connectPeerMessage struct {
+	p              peer.ID
+	initialEntries []*wantlist.Entry
+}
+
+func (c *connectPeerMessage) handle(pm *PeerManager) {
+	pm.startPeerHandler(c.p, c.initialEntries)
+}
+
+type disconnectPeerMessage struct {
+	p peer.ID
+}
+
+func (dc *disconnectPeerMessage) handle(pm *PeerManager) {
+	pm.stopPeerHandler(dc.p)
+}
+
+type getPeersMessage struct {
+	peerResp chan<- []peer.ID
+}
+
+func (gp *getPeersMessage) handle(pm *PeerManager) {
+	pm.getPeers(gp.peerResp)
+}
+
+func (pm *PeerManager) getPeers(peerResp chan<- []peer.ID) {
+	peers := make([]peer.ID, 0, len(pm.peerQueues))
+	for p := range pm.peerQueues {
+		peers = append(peers, p)
+	}
+	peerResp <- peers
 }
 
 func (pm *PeerManager) startPeerHandler(p peer.ID, initialEntries []*wantlist.Entry) PeerQueue {
@@ -110,83 +183,19 @@ func (pm *PeerManager) stopPeerHandler(p peer.ID) {
 	delete(pm.peerQueues, p)
 }
 
-func (pm *PeerManager) Connected(p peer.ID, initialEntries []*wantlist.Entry) {
-	select {
-	case pm.peerMessages <- peerMessage{connect, connectParams{peer: p, initialEntries: initialEntries}, nil}:
-	case <-pm.ctx.Done():
-	}
-}
-
-func (pm *PeerManager) Disconnected(p peer.ID) {
-	select {
-	case pm.peerMessages <- peerMessage{disconnect, p, nil}:
-	case <-pm.ctx.Done():
-	}
-}
-
-func (pm *PeerManager) SendMessage(entries []*bsmsg.Entry, targets []peer.ID, from uint64) {
-	select {
-	case pm.peerMessages <- peerMessage{
-		sendMessage,
-		&sendMessageParams{entries: entries, targets: targets, from: from},
-		nil,
-	}:
-	case <-pm.ctx.Done():
-	}
-}
-
-func (pm *PeerManager) Startup() {
-	go pm.run()
-}
-
-func (pm *PeerManager) Shutdown() {
-	pm.cancel()
-}
-
-// TODO: use goprocess here once i trust it
-func (pm *PeerManager) run() {
-	// NOTE: Do not open any streams or connections from anywhere in this
-	// event loop. Really, just don't do anything likely to block.
-	for {
-		select {
-		case message := <-pm.peerMessages:
-			pm.handleMessage(message)
-		case <-pm.ctx.Done():
-			return
+func (pm *PeerManager) sendMessage(ms *sendPeerMessage) {
+	if len(ms.targets) == 0 {
+		for _, p := range pm.peerQueues {
+			p.AddMessage(ms.entries, ms.from)
 		}
-	}
-}
-
-func (pm *PeerManager) handleMessage(message peerMessage) {
-
-	switch message.messageType {
-	case sendMessage:
-		ms := message.params.(*sendMessageParams)
-		if len(ms.targets) == 0 {
-			for _, p := range pm.peerQueues {
-				p.AddMessage(ms.entries, ms.from)
+	} else {
+		for _, t := range ms.targets {
+			p, ok := pm.peerQueues[t]
+			if !ok {
+				log.Infof("tried sending wantlist change to non-partner peer: %s", t)
+				continue
 			}
-		} else {
-			for _, t := range ms.targets {
-				p, ok := pm.peerQueues[t]
-				if !ok {
-					log.Infof("tried sending wantlist change to non-partner peer: %s", t)
-					continue
-				}
-				p.AddMessage(ms.entries, ms.from)
-			}
+			p.AddMessage(ms.entries, ms.from)
 		}
-	case connect:
-		p := message.params.(connectParams)
-		pm.startPeerHandler(p.peer, p.initialEntries)
-	case disconnect:
-		disconnectPeer := message.params.(peer.ID)
-		pm.stopPeerHandler(disconnectPeer)
-	case getPeers:
-		peers := make([]peer.ID, 0, len(pm.peerQueues))
-		for p := range pm.peerQueues {
-			peers = append(peers, p)
-		}
-		message.resultsChan <- peers
 	}
 }

--- a/peermanager/peermanager_test.go
+++ b/peermanager/peermanager_test.go
@@ -131,13 +131,13 @@ func TestSendingMessagesToPeers(t *testing.T) {
 	peerManager.Connected(peer2, nil)
 	peerManager.Connected(peer3, nil)
 
-	entries := testutil.GenerateEntries(5, false)
+	entries := testutil.GenerateMessageEntries(5, false)
 	ses := testutil.GenerateSessionID()
 
 	peerManager.SendMessage(entries, nil, ses)
 
 	peersReceived := collectAndCheckMessages(
-		ctx, t, messagesSent, entries, ses, 200*time.Millisecond)
+		ctx, t, messagesSent, entries, ses, 10*time.Millisecond)
 	if len(peersReceived) != 3 {
 		t.Fatal("Incorrect number of peers received messages")
 	}
@@ -157,7 +157,7 @@ func TestSendingMessagesToPeers(t *testing.T) {
 	peersToSendTo = append(peersToSendTo, peer1, peer3, peer4)
 	peerManager.SendMessage(entries, peersToSendTo, ses)
 	peersReceived = collectAndCheckMessages(
-		ctx, t, messagesSent, entries, ses, 200*time.Millisecond)
+		ctx, t, messagesSent, entries, ses, 10*time.Millisecond)
 
 	if len(peersReceived) != 2 {
 		t.Fatal("Incorrect number of peers received messages")

--- a/peermanager/peermanager_test.go
+++ b/peermanager/peermanager_test.go
@@ -1,0 +1,128 @@
+package peermanager
+
+import (
+	"context"
+	"testing"
+
+	bsmsg "github.com/ipfs/go-bitswap/message"
+	wantlist "github.com/ipfs/go-bitswap/wantlist"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-ipfs-blocksutil"
+	"github.com/libp2p/go-libp2p-peer"
+)
+
+var blockGenerator = blocksutil.NewBlockGenerator()
+
+func generateCids(n int) []cid.Cid {
+	cids := make([]cid.Cid, 0, n)
+	for i := 0; i < n; i++ {
+		c := blockGenerator.Next().Cid()
+		cids = append(cids, c)
+	}
+	return cids
+}
+
+var peerSeq int
+
+func generatePeers(n int) []peer.ID {
+	peerIds := make([]peer.ID, 0, n)
+	for i := 0; i < n; i++ {
+		peerSeq++
+		p := peer.ID(peerSeq)
+		peerIds = append(peerIds, p)
+	}
+	return peerIds
+}
+
+var nextSession uint64
+
+func generateSessionID() uint64 {
+	nextSession++
+	return uint64(nextSession)
+}
+
+type messageSent struct {
+	p       peer.ID
+	entries []*bsmsg.Entry
+	ses     uint64
+}
+
+type fakePeer struct {
+	refcnt       int
+	p            peer.ID
+	messagesSent chan messageSent
+}
+
+func containsPeer(peers []peer.ID, p peer.ID) bool {
+	for _, n := range peers {
+		if p == n {
+			return true
+		}
+	}
+	return false
+}
+
+func (fp *fakePeer) Startup(ctx context.Context, initialEntries []*wantlist.Entry) {}
+func (fp *fakePeer) Shutdown()                                                     {}
+func (fp *fakePeer) RefIncrement()                                                 { fp.refcnt++ }
+func (fp *fakePeer) RefDecrement() bool {
+	fp.refcnt--
+	return fp.refcnt > 0
+}
+func (fp *fakePeer) AddMessage(entries []*bsmsg.Entry, ses uint64) {
+	fp.messagesSent <- messageSent{fp.p, entries, ses}
+}
+
+func makePeerQueueFactory(messagesSent chan messageSent) PeerQueueFactory {
+	return func(p peer.ID) PeerQueue {
+		return &fakePeer{
+			p:            p,
+			refcnt:       1,
+			messagesSent: messagesSent,
+		}
+	}
+}
+
+func TestAddingAndRemovingPeers(t *testing.T) {
+	ctx := context.Background()
+	peerQueueFactory := makePeerQueueFactory(nil)
+
+	tp := generatePeers(5)
+	peer1, peer2, peer3, peer4, peer5 := tp[0], tp[1], tp[2], tp[3], tp[4]
+	peerManager := New(ctx, peerQueueFactory)
+	peerManager.Startup()
+
+	peerManager.Connected(peer1, nil)
+	peerManager.Connected(peer2, nil)
+	peerManager.Connected(peer3, nil)
+
+	connectedPeers := peerManager.ConnectedPeers()
+
+	if !containsPeer(connectedPeers, peer1) ||
+		!containsPeer(connectedPeers, peer2) ||
+		!containsPeer(connectedPeers, peer3) {
+		t.Fatal("Peers not connected that should be connected")
+	}
+
+	if containsPeer(connectedPeers, peer4) ||
+		containsPeer(connectedPeers, peer5) {
+		t.Fatal("Peers connected that shouldn't be connected")
+	}
+
+	// removing a peer with only one reference
+	peerManager.Disconnected(peer1)
+	connectedPeers = peerManager.ConnectedPeers()
+
+	if containsPeer(connectedPeers, peer1) {
+		t.Fatal("Peer should have been disconnected but was not")
+	}
+
+	// connecting a peer twice, then disconnecting once, should stay in queue
+	peerManager.Connected(peer2, nil)
+	peerManager.Disconnected(peer2)
+	connectedPeers = peerManager.ConnectedPeers()
+
+	if !containsPeer(connectedPeers, peer2) {
+		t.Fatal("Peer was disconnected but should not have been")
+	}
+}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -21,8 +21,19 @@ func GenerateCids(n int) []cid.Cid {
 	return cids
 }
 
-// GenerateEntries makes fake bitswap message entries
-func GenerateEntries(n int, isCancel bool) []*bsmsg.Entry {
+// GenerateWantlist makes a populated wantlist
+func GenerateWantlist(n int, ses uint64) *wantlist.ThreadSafe {
+	wl := wantlist.NewThreadSafe()
+	for i := 0; i < n; i++ {
+		prioritySeq++
+		entry := wantlist.NewRefEntry(blockGenerator.Next().Cid(), prioritySeq)
+		wl.AddEntry(entry, ses)
+	}
+	return wl
+}
+
+// GenerateMessageEntries makes fake bitswap message entries
+func GenerateMessageEntries(n int, isCancel bool) []*bsmsg.Entry {
 	bsmsgs := make([]*bsmsg.Entry, 0, n)
 	for i := 0; i < n; i++ {
 		prioritySeq++

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,0 +1,67 @@
+package testutil
+
+import (
+	bsmsg "github.com/ipfs/go-bitswap/message"
+	"github.com/ipfs/go-bitswap/wantlist"
+	cid "github.com/ipfs/go-cid"
+	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+var blockGenerator = blocksutil.NewBlockGenerator()
+var prioritySeq int
+
+// GenerateCids produces n content identifiers
+func GenerateCids(n int) []cid.Cid {
+	cids := make([]cid.Cid, 0, n)
+	for i := 0; i < n; i++ {
+		c := blockGenerator.Next().Cid()
+		cids = append(cids, c)
+	}
+	return cids
+}
+
+// GenerateEntries makes fake bitswap message entries
+func GenerateEntries(n int, isCancel bool) []*bsmsg.Entry {
+	bsmsgs := make([]*bsmsg.Entry, 0, n)
+	for i := 0; i < n; i++ {
+		prioritySeq++
+		msg := &bsmsg.Entry{
+			Entry:  wantlist.NewRefEntry(blockGenerator.Next().Cid(), prioritySeq),
+			Cancel: isCancel,
+		}
+		bsmsgs = append(bsmsgs, msg)
+	}
+	return bsmsgs
+}
+
+var peerSeq int
+
+// GeneratePeers creates n peer ids
+func GeneratePeers(n int) []peer.ID {
+	peerIds := make([]peer.ID, 0, n)
+	for i := 0; i < n; i++ {
+		peerSeq++
+		p := peer.ID(peerSeq)
+		peerIds = append(peerIds, p)
+	}
+	return peerIds
+}
+
+var nextSession uint64
+
+// GenerateSessionID make a unit session identifier
+func GenerateSessionID() uint64 {
+	nextSession++
+	return uint64(nextSession)
+}
+
+// ContainsPeer returns true if a peer is found n a list of peers
+func ContainsPeer(peers []peer.ID, p peer.ID) bool {
+	for _, n := range peers {
+		if p == n {
+			return true
+		}
+	}
+	return false
+}

--- a/wantmanager/wantmanager_test.go
+++ b/wantmanager/wantmanager_test.go
@@ -6,41 +6,12 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/ipfs/go-bitswap/testutil"
+
 	bsmsg "github.com/ipfs/go-bitswap/message"
 	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-ipfs-blocksutil"
 	"github.com/libp2p/go-libp2p-peer"
 )
-
-var blockGenerator = blocksutil.NewBlockGenerator()
-
-func generateCids(n int) []cid.Cid {
-	cids := make([]cid.Cid, 0, n)
-	for i := 0; i < n; i++ {
-		c := blockGenerator.Next().Cid()
-		cids = append(cids, c)
-	}
-	return cids
-}
-
-var peerSeq int
-
-func generatePeers(n int) []peer.ID {
-	peerIds := make([]peer.ID, 0, n)
-	for i := 0; i < n; i++ {
-		peerSeq++
-		p := peer.ID(peerSeq)
-		peerIds = append(peerIds, p)
-	}
-	return peerIds
-}
-
-var nextSession uint64
-
-func generateSessionID() uint64 {
-	nextSession++
-	return uint64(nextSession)
-}
 
 type fakeWantSender struct {
 	lk          sync.RWMutex
@@ -66,11 +37,11 @@ func setupTestFixturesAndInitialWantList() (
 	// setup fixtures
 	wantSender := &fakeWantSender{}
 	wantManager := New(ctx)
-	keys := generateCids(10)
-	otherKeys := generateCids(5)
-	peers := generatePeers(10)
-	session := generateSessionID()
-	otherSession := generateSessionID()
+	keys := testutil.GenerateCids(10)
+	otherKeys := testutil.GenerateCids(5)
+	peers := testutil.GeneratePeers(10)
+	session := testutil.GenerateSessionID()
+	otherSession := testutil.GenerateSessionID()
 
 	// startup wantManager
 	wantManager.SetDelegate(wantSender)

--- a/wantmanager/wantmanager_test.go
+++ b/wantmanager/wantmanager_test.go
@@ -1,0 +1,244 @@
+package wantmanager
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+
+	bsmsg "github.com/ipfs/go-bitswap/message"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-ipfs-blocksutil"
+	"github.com/libp2p/go-libp2p-peer"
+)
+
+var blockGenerator = blocksutil.NewBlockGenerator()
+
+func generateCids(n int) []cid.Cid {
+	cids := make([]cid.Cid, 0, n)
+	for i := 0; i < n; i++ {
+		c := blockGenerator.Next().Cid()
+		cids = append(cids, c)
+	}
+	return cids
+}
+
+var peerSeq int
+
+func generatePeers(n int) []peer.ID {
+	peerIds := make([]peer.ID, 0, n)
+	for i := 0; i < n; i++ {
+		peerSeq++
+		p := peer.ID(peerSeq)
+		peerIds = append(peerIds, p)
+	}
+	return peerIds
+}
+
+var nextSession uint64
+
+func generateSessionID() uint64 {
+	nextSession++
+	return uint64(nextSession)
+}
+
+type fakeWantSender struct {
+	lk          sync.RWMutex
+	lastWantSet wantSet
+}
+
+func (fws *fakeWantSender) SendMessage(entries []*bsmsg.Entry, targets []peer.ID, from uint64) {
+	fws.lk.Lock()
+	fws.lastWantSet = wantSet{entries, targets, from}
+	fws.lk.Unlock()
+}
+
+func (fws *fakeWantSender) getLastWantSet() wantSet {
+	fws.lk.Lock()
+	defer fws.lk.Unlock()
+	return fws.lastWantSet
+}
+
+func setupTestFixturesAndInitialWantList() (
+	context.Context, *fakeWantSender, *WantManager, []cid.Cid, []cid.Cid, []peer.ID, uint64, uint64) {
+	ctx := context.Background()
+
+	// setup fixtures
+	wantSender := &fakeWantSender{}
+	wantManager := New(ctx)
+	keys := generateCids(10)
+	otherKeys := generateCids(5)
+	peers := generatePeers(10)
+	session := generateSessionID()
+	otherSession := generateSessionID()
+
+	// startup wantManager
+	wantManager.SetDelegate(wantSender)
+	wantManager.Startup()
+
+	// add initial wants
+	wantManager.WantBlocks(
+		ctx,
+		keys,
+		peers,
+		session)
+
+	return ctx, wantSender, wantManager, keys, otherKeys, peers, session, otherSession
+}
+
+func TestInitialWantsAddedCorrectly(t *testing.T) {
+
+	_, wantSender, wantManager, keys, _, peers, session, _ :=
+		setupTestFixturesAndInitialWantList()
+
+	bcwl := wantManager.CurrentBroadcastWants()
+	wl := wantManager.CurrentWants()
+
+	if len(bcwl) > 0 {
+		t.Fatal("should not create broadcast wants when peers are specified")
+	}
+
+	if len(wl) != len(keys) {
+		t.Fatal("did not add correct number of wants to want lsit")
+	}
+
+	generatedWantSet := wantSender.getLastWantSet()
+
+	if len(generatedWantSet.entries) != len(keys) {
+		t.Fatal("incorrect wants sent")
+	}
+
+	for _, entry := range generatedWantSet.entries {
+		if entry.Cancel {
+			t.Fatal("did not send only non-cancel messages")
+		}
+	}
+
+	if generatedWantSet.from != session {
+		t.Fatal("incorrect session used in sending")
+	}
+
+	if !reflect.DeepEqual(generatedWantSet.targets, peers) {
+		t.Fatal("did not setup peers correctly")
+	}
+
+	wantManager.Shutdown()
+}
+
+func TestCancellingWants(t *testing.T) {
+	ctx, wantSender, wantManager, keys, _, peers, session, _ :=
+		setupTestFixturesAndInitialWantList()
+
+	wantManager.CancelWants(ctx, keys, peers, session)
+
+	wl := wantManager.CurrentWants()
+
+	if len(wl) != 0 {
+		t.Fatal("did not remove blocks from want list")
+	}
+
+	generatedWantSet := wantSender.getLastWantSet()
+
+	if len(generatedWantSet.entries) != len(keys) {
+		t.Fatal("incorrect wants sent")
+	}
+
+	for _, entry := range generatedWantSet.entries {
+		if !entry.Cancel {
+			t.Fatal("did not send only cancel messages")
+		}
+	}
+
+	if generatedWantSet.from != session {
+		t.Fatal("incorrect session used in sending")
+	}
+
+	if !reflect.DeepEqual(generatedWantSet.targets, peers) {
+		t.Fatal("did not setup peers correctly")
+	}
+
+	wantManager.Shutdown()
+
+}
+
+func TestCancellingWantsFromAnotherSessionHasNoEffect(t *testing.T) {
+	ctx, _, wantManager, keys, _, peers, _, otherSession :=
+		setupTestFixturesAndInitialWantList()
+
+	// cancelling wants from another session has no effect
+	wantManager.CancelWants(ctx, keys, peers, otherSession)
+
+	wl := wantManager.CurrentWants()
+
+	if len(wl) != len(keys) {
+		t.Fatal("should not cancel wants unless they match session that made them")
+	}
+
+	wantManager.Shutdown()
+}
+
+func TestAddingWantsWithNoPeersAddsToBroadcastAndRegularWantList(t *testing.T) {
+	ctx, _, wantManager, keys, otherKeys, _, session, _ :=
+		setupTestFixturesAndInitialWantList()
+
+	wantManager.WantBlocks(ctx, otherKeys, nil, session)
+
+	bcwl := wantManager.CurrentBroadcastWants()
+	wl := wantManager.CurrentWants()
+
+	if len(bcwl) != len(otherKeys) {
+		t.Fatal("want requests with no peers should get added to broadcast list")
+	}
+
+	if len(wl) != len(otherKeys)+len(keys) {
+		t.Fatal("want requests with no peers should get added to regular want list")
+	}
+
+	wantManager.Shutdown()
+}
+
+func TestAddingRequestFromSecondSessionPreventsCancel(t *testing.T) {
+	ctx, wantSender, wantManager, keys, _, peers, session, otherSession :=
+		setupTestFixturesAndInitialWantList()
+
+	// add a second session requesting the first key
+	firstKeys := append([]cid.Cid(nil), keys[0])
+	wantManager.WantBlocks(ctx, firstKeys, peers, otherSession)
+
+	wl := wantManager.CurrentWants()
+
+	if len(wl) != len(keys) {
+		t.Fatal("wants from other sessions should not get added seperately")
+	}
+
+	generatedWantSet := wantSender.getLastWantSet()
+	if len(generatedWantSet.entries) != len(firstKeys) &&
+		generatedWantSet.from != otherSession &&
+		generatedWantSet.entries[0].Cid != firstKeys[0] &&
+		generatedWantSet.entries[0].Cancel != false {
+		t.Fatal("should send additional message requesting want for new session")
+	}
+
+	// cancel block from first session
+	wantManager.CancelWants(ctx, firstKeys, peers, session)
+
+	wl = wantManager.CurrentWants()
+
+	// want should still be on want list
+	if len(wl) != len(keys) {
+		t.Fatal("wants should not be removed until all sessions cancel wants")
+	}
+
+	// cancel other block from first session
+	secondKeys := append([]cid.Cid(nil), keys[1])
+	wantManager.CancelWants(ctx, secondKeys, peers, session)
+
+	wl = wantManager.CurrentWants()
+
+	// want should not be on want list, cause it was only tracked by one session
+	if len(wl) != len(keys)-1 {
+		t.Fatal("wants should be removed if all sessions have cancelled")
+	}
+
+	wantManager.Shutdown()
+}


### PR DESCRIPTION
# Goals

Modularize Bitswap in preparation for attempts to optimize bitswap further

child of #26 

# Implementation

- Seperated out a PeerManager, which was part of WantManager but doesn't seem at all tied to managing peers
- Made unit tests for PeerManager and WantManager
- Discovered issues while unit testing with synchronization of calls that lead to unpredictable output and refactored both classes to process messages serially to provide a predictable interface (apologies for bringing in erlang like actor pattern habits of using message passing)
- Moved SendBlocks function which seemed like a one off that had little to do with WantManager back in main bitswap package for now
- Comment remaining public interfaces