### PR TITLE
WIP: Speed up sessions round 2

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -37,7 +37,7 @@ var benchmarkLog []runStats
 func BenchmarkDups2Nodes(b *testing.B) {
 	benchmarkLog = nil
 	fixedDelay := delay.Fixed(10 * time.Millisecond)
-	/*b.Run("AllToAll-OneAtATime", func(b *testing.B) {
+	b.Run("AllToAll-OneAtATime", func(b *testing.B) {
 		subtestDistributeAndFetch(b, 3, 100, fixedDelay, allToAll, oneAtATime)
 	})
 	b.Run("AllToAll-BigBatch", func(b *testing.B) {
@@ -81,19 +81,19 @@ func BenchmarkDups2Nodes(b *testing.B) {
 	})
 	b.Run("10Nodes-AllToAll-UnixfsFetch", func(b *testing.B) {
 		subtestDistributeAndFetch(b, 10, 100, fixedDelay, allToAll, unixfsFileFetch)
-	})*/
+	})
 	b.Run("10Nodes-OnePeerPerBlock-OneAtATime", func(b *testing.B) {
 		subtestDistributeAndFetch(b, 10, 100, fixedDelay, onePeerPerBlock, oneAtATime)
-	}) /*
-		b.Run("10Nodes-OnePeerPerBlock-BigBatch", func(b *testing.B) {
-			subtestDistributeAndFetch(b, 10, 100, fixedDelay, onePeerPerBlock, batchFetchAll)
-		})
-		b.Run("10Nodes-OnePeerPerBlock-UnixfsFetch", func(b *testing.B) {
-			subtestDistributeAndFetch(b, 10, 100, fixedDelay, onePeerPerBlock, unixfsFileFetch)
-		})
-		b.Run("200Nodes-AllToAll-BigBatch", func(b *testing.B) {
-			subtestDistributeAndFetch(b, 200, 20, fixedDelay, allToAll, batchFetchAll)
-		})*/
+	})
+	b.Run("10Nodes-OnePeerPerBlock-BigBatch", func(b *testing.B) {
+		subtestDistributeAndFetch(b, 10, 100, fixedDelay, onePeerPerBlock, batchFetchAll)
+	})
+	b.Run("10Nodes-OnePeerPerBlock-UnixfsFetch", func(b *testing.B) {
+		subtestDistributeAndFetch(b, 10, 100, fixedDelay, onePeerPerBlock, unixfsFileFetch)
+	})
+	b.Run("200Nodes-AllToAll-BigBatch", func(b *testing.B) {
+		subtestDistributeAndFetch(b, 200, 20, fixedDelay, allToAll, batchFetchAll)
+	})
 	out, _ := json.MarshalIndent(benchmarkLog, "", "  ")
 	ioutil.WriteFile("tmp/benchmark.json", out, 0666)
 }
@@ -111,7 +111,6 @@ const slowBandwidth = 100000.0
 const slowBandwidthDeviation = 16500.0
 const stdBlockSize = 8000
 
-/*
 func BenchmarkDupsManyNodesRealWorldNetwork(b *testing.B) {
 	benchmarkLog = nil
 	fastNetworkDelayGenerator := tn.InternetLatencyDelayGenerator(
@@ -142,7 +141,7 @@ func BenchmarkDupsManyNodesRealWorldNetwork(b *testing.B) {
 	out, _ := json.MarshalIndent(benchmarkLog, "", "  ")
 	ioutil.WriteFile("tmp/rw-benchmark.json", out, 0666)
 }
-*/
+
 func subtestDistributeAndFetch(b *testing.B, numnodes, numblks int, d delay.D, df distFunc, ff fetchFunc) {
 	start := time.Now()
 	net := tn.VirtualNetwork(mockrouting.NewServer(), d)

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -37,7 +37,7 @@ var benchmarkLog []runStats
 func BenchmarkDups2Nodes(b *testing.B) {
 	benchmarkLog = nil
 	fixedDelay := delay.Fixed(10 * time.Millisecond)
-	b.Run("AllToAll-OneAtATime", func(b *testing.B) {
+	/*b.Run("AllToAll-OneAtATime", func(b *testing.B) {
 		subtestDistributeAndFetch(b, 3, 100, fixedDelay, allToAll, oneAtATime)
 	})
 	b.Run("AllToAll-BigBatch", func(b *testing.B) {
@@ -81,19 +81,19 @@ func BenchmarkDups2Nodes(b *testing.B) {
 	})
 	b.Run("10Nodes-AllToAll-UnixfsFetch", func(b *testing.B) {
 		subtestDistributeAndFetch(b, 10, 100, fixedDelay, allToAll, unixfsFileFetch)
-	})
+	})*/
 	b.Run("10Nodes-OnePeerPerBlock-OneAtATime", func(b *testing.B) {
 		subtestDistributeAndFetch(b, 10, 100, fixedDelay, onePeerPerBlock, oneAtATime)
-	})
-	b.Run("10Nodes-OnePeerPerBlock-BigBatch", func(b *testing.B) {
-		subtestDistributeAndFetch(b, 10, 100, fixedDelay, onePeerPerBlock, batchFetchAll)
-	})
-	b.Run("10Nodes-OnePeerPerBlock-UnixfsFetch", func(b *testing.B) {
-		subtestDistributeAndFetch(b, 10, 100, fixedDelay, onePeerPerBlock, unixfsFileFetch)
-	})
-	b.Run("200Nodes-AllToAll-BigBatch", func(b *testing.B) {
-		subtestDistributeAndFetch(b, 200, 20, fixedDelay, allToAll, batchFetchAll)
-	})
+	}) /*
+		b.Run("10Nodes-OnePeerPerBlock-BigBatch", func(b *testing.B) {
+			subtestDistributeAndFetch(b, 10, 100, fixedDelay, onePeerPerBlock, batchFetchAll)
+		})
+		b.Run("10Nodes-OnePeerPerBlock-UnixfsFetch", func(b *testing.B) {
+			subtestDistributeAndFetch(b, 10, 100, fixedDelay, onePeerPerBlock, unixfsFileFetch)
+		})
+		b.Run("200Nodes-AllToAll-BigBatch", func(b *testing.B) {
+			subtestDistributeAndFetch(b, 200, 20, fixedDelay, allToAll, batchFetchAll)
+		})*/
 	out, _ := json.MarshalIndent(benchmarkLog, "", "  ")
 	ioutil.WriteFile("tmp/benchmark.json", out, 0666)
 }
@@ -111,6 +111,7 @@ const slowBandwidth = 100000.0
 const slowBandwidthDeviation = 16500.0
 const stdBlockSize = 8000
 
+/*
 func BenchmarkDupsManyNodesRealWorldNetwork(b *testing.B) {
 	benchmarkLog = nil
 	fastNetworkDelayGenerator := tn.InternetLatencyDelayGenerator(
@@ -141,7 +142,7 @@ func BenchmarkDupsManyNodesRealWorldNetwork(b *testing.B) {
 	out, _ := json.MarshalIndent(benchmarkLog, "", "  ")
 	ioutil.WriteFile("tmp/rw-benchmark.json", out, 0666)
 }
-
+*/
 func subtestDistributeAndFetch(b *testing.B, numnodes, numblks int, d delay.D, df distFunc, ff fetchFunc) {
 	start := time.Now()
 	net := tn.VirtualNetwork(mockrouting.NewServer(), d)

--- a/bitswap.go
+++ b/bitswap.go
@@ -306,7 +306,7 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 			defer wg.Done()
 
 			bs.updateReceiveCounters(b)
-			bs.sm.UpdateReceiveCounters(b)
+			bs.sm.UpdateReceiveCounters(p, b)
 			log.Debugf("got block %s from %s", b, p)
 
 			// skip received blocks that are not in the wantlist

--- a/session/session.go
+++ b/session/session.go
@@ -7,13 +7,12 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	bsgetter "github.com/ipfs/go-bitswap/getter"
 	notifications "github.com/ipfs/go-bitswap/notifications"
+	bssd "github.com/ipfs/go-bitswap/sessiondata"
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
 	loggables "github.com/libp2p/go-libp2p-loggables"
 	peer "github.com/libp2p/go-libp2p-peer"
-
-	bssrs "github.com/ipfs/go-bitswap/sessionrequestsplitter"
 )
 
 const (
@@ -32,7 +31,7 @@ type WantManager interface {
 // requesting more when neccesary.
 type PeerManager interface {
 	FindMorePeers(context.Context, cid.Cid)
-	GetOptimizedPeers() []peer.ID
+	GetOptimizedPeers() []bssd.OptimizedPeer
 	RecordPeerRequests([]peer.ID, []cid.Cid)
 	RecordPeerResponse(peer.ID, cid.Cid)
 }
@@ -40,7 +39,7 @@ type PeerManager interface {
 // RequestSplitter provides an interface for splitting
 // a request for Cids up among peers.
 type RequestSplitter interface {
-	SplitRequest([]peer.ID, []cid.Cid) []*bssrs.PartialRequest
+	SplitRequest([]bssd.OptimizedPeer, []cid.Cid) []bssd.PartialRequest
 	RecordDuplicateBlock()
 	RecordUniqueBlock()
 }

--- a/session/session.go
+++ b/session/session.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru"
@@ -298,7 +297,6 @@ func (s *Session) handleCancel(keys []cid.Cid) {
 }
 
 func (s *Session) handleTick(ctx context.Context) {
-	fmt.Println("Tick!")
 	live := make([]cid.Cid, 0, len(s.liveWants))
 	now := time.Now()
 	for c := range s.liveWants {

--- a/session/session.go
+++ b/session/session.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru"
@@ -263,6 +264,7 @@ func (s *Session) handleIncomingBlock(ctx context.Context, blk blkRecv) {
 	s.tick.Stop()
 
 	if blk.from != "" {
+		fmt.Println(blk.from.Pretty())
 		s.pm.RecordPeerResponse(blk.from, blk.blk.Cid())
 	}
 

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ipfs/go-block-format"
 
-	bssrs "github.com/ipfs/go-bitswap/sessionrequestsplitter"
+	bssd "github.com/ipfs/go-bitswap/sessiondata"
 	"github.com/ipfs/go-bitswap/testutil"
 	cid "github.com/ipfs/go-cid"
 	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
@@ -52,10 +52,14 @@ func (fpm *fakePeerManager) FindMorePeers(ctx context.Context, k cid.Cid) {
 	}
 }
 
-func (fpm *fakePeerManager) GetOptimizedPeers() []peer.ID {
+func (fpm *fakePeerManager) GetOptimizedPeers() []bssd.OptimizedPeer {
 	fpm.lk.Lock()
 	defer fpm.lk.Unlock()
-	return fpm.peers
+	optimizedPeers := make([]bssd.OptimizedPeer, 0, len(fpm.peers))
+	for _, peer := range fpm.peers {
+		optimizedPeers = append(optimizedPeers, bssd.OptimizedPeer{Peer: peer, OptimizationRating: 1.0})
+	}
+	return optimizedPeers
 }
 
 func (fpm *fakePeerManager) RecordPeerRequests([]peer.ID, []cid.Cid) {}
@@ -68,8 +72,12 @@ func (fpm *fakePeerManager) RecordPeerResponse(p peer.ID, c cid.Cid) {
 type fakeRequestSplitter struct {
 }
 
-func (frs *fakeRequestSplitter) SplitRequest(peers []peer.ID, keys []cid.Cid) []*bssrs.PartialRequest {
-	return []*bssrs.PartialRequest{&bssrs.PartialRequest{Peers: peers, Keys: keys}}
+func (frs *fakeRequestSplitter) SplitRequest(optimizedPeers []bssd.OptimizedPeer, keys []cid.Cid) []bssd.PartialRequest {
+	peers := make([]peer.ID, len(optimizedPeers))
+	for i, optimizedPeer := range optimizedPeers {
+		peers[i] = optimizedPeer.Peer
+	}
+	return []bssd.PartialRequest{bssd.PartialRequest{Peers: peers, Keys: keys}}
 }
 
 func (frs *fakeRequestSplitter) RecordDuplicateBlock() {}

--- a/sessiondata/sessiondata.go
+++ b/sessiondata/sessiondata.go
@@ -1,0 +1,18 @@
+package sessiondata
+
+import (
+	cid "github.com/ipfs/go-cid"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+// OptimizedPeer describes a peer and its level of optimization from 0 to 1.
+type OptimizedPeer struct {
+	Peer               peer.ID
+	OptimizationRating float64
+}
+
+// PartialRequest is represents one slice of an over request split among peers
+type PartialRequest struct {
+	Peers []peer.ID
+	Keys  []cid.Cid
+}

--- a/sessionmanager/sessionmanager.go
+++ b/sessionmanager/sessionmanager.go
@@ -17,7 +17,7 @@ type Session interface {
 	exchange.Fetcher
 	InterestedIn(cid.Cid) bool
 	ReceiveBlockFrom(peer.ID, blocks.Block)
-	UpdateReceiveCounters(blocks.Block)
+	UpdateReceiveCounters(peer.ID, blocks.Block)
 }
 
 type sesTrk struct {
@@ -124,11 +124,11 @@ func (sm *SessionManager) ReceiveBlockFrom(from peer.ID, blk blocks.Block) {
 
 // UpdateReceiveCounters records the fact that a block was received, allowing
 // sessions to track duplicates
-func (sm *SessionManager) UpdateReceiveCounters(blk blocks.Block) {
+func (sm *SessionManager) UpdateReceiveCounters(from peer.ID, blk blocks.Block) {
 	sm.sessLk.Lock()
 	defer sm.sessLk.Unlock()
 
 	for _, s := range sm.sessions {
-		s.session.UpdateReceiveCounters(blk)
+		s.session.UpdateReceiveCounters(from, blk)
 	}
 }

--- a/sessionmanager/sessionmanager_test.go
+++ b/sessionmanager/sessionmanager_test.go
@@ -5,9 +5,8 @@ import (
 	"testing"
 	"time"
 
-	bssrs "github.com/ipfs/go-bitswap/sessionrequestsplitter"
-
 	bssession "github.com/ipfs/go-bitswap/session"
+	bssd "github.com/ipfs/go-bitswap/sessiondata"
 
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
@@ -38,14 +37,14 @@ type fakePeerManager struct {
 }
 
 func (*fakePeerManager) FindMorePeers(context.Context, cid.Cid)  {}
-func (*fakePeerManager) GetOptimizedPeers() []peer.ID            { return nil }
+func (*fakePeerManager) GetOptimizedPeers() []bssd.OptimizedPeer { return nil }
 func (*fakePeerManager) RecordPeerRequests([]peer.ID, []cid.Cid) {}
 func (*fakePeerManager) RecordPeerResponse(peer.ID, cid.Cid)     {}
 
 type fakeRequestSplitter struct {
 }
 
-func (frs *fakeRequestSplitter) SplitRequest(peers []peer.ID, keys []cid.Cid) []*bssrs.PartialRequest {
+func (frs *fakeRequestSplitter) SplitRequest(optimizedPeers []bssd.OptimizedPeer, keys []cid.Cid) []bssd.PartialRequest {
 	return nil
 }
 func (frs *fakeRequestSplitter) RecordDuplicateBlock() {}

--- a/sessionmanager/sessionmanager_test.go
+++ b/sessionmanager/sessionmanager_test.go
@@ -28,9 +28,9 @@ func (*fakeSession) GetBlock(context.Context, cid.Cid) (blocks.Block, error) {
 func (*fakeSession) GetBlocks(context.Context, []cid.Cid) (<-chan blocks.Block, error) {
 	return nil, nil
 }
-func (fs *fakeSession) InterestedIn(cid.Cid) bool              { return fs.interested }
-func (fs *fakeSession) ReceiveBlockFrom(peer.ID, blocks.Block) { fs.receivedBlock = true }
-func (fs *fakeSession) UpdateReceiveCounters(blocks.Block)     { fs.updateReceiveCounters = true }
+func (fs *fakeSession) InterestedIn(cid.Cid) bool                   { return fs.interested }
+func (fs *fakeSession) ReceiveBlockFrom(peer.ID, blocks.Block)      { fs.receivedBlock = true }
+func (fs *fakeSession) UpdateReceiveCounters(peer.ID, blocks.Block) { fs.updateReceiveCounters = true }
 
 type fakePeerManager struct {
 	id uint64

--- a/sessionpeermanager/latencytracker.go
+++ b/sessionpeermanager/latencytracker.go
@@ -1,0 +1,65 @@
+package sessionpeermanager
+
+import (
+	"time"
+
+	"github.com/ipfs/go-cid"
+)
+
+const (
+	timeoutDuration = 5 * time.Second
+)
+
+type requestData struct {
+	startedAt   time.Time
+	timeoutFunc *time.Timer
+}
+
+type latencyTracker struct {
+	requests map[cid.Cid]*requestData
+}
+
+func newLatencyTracker() *latencyTracker {
+	return &latencyTracker{requests: make(map[cid.Cid]*requestData)}
+}
+
+type afterTimeoutFunc func(cid.Cid)
+
+func (lt *latencyTracker) SetupRequests(keys []cid.Cid, afterTimeout afterTimeoutFunc) {
+	startedAt := time.Now()
+	for _, k := range keys {
+		if _, ok := lt.requests[k]; !ok {
+			lt.requests[k] = &requestData{startedAt, time.AfterFunc(timeoutDuration, makeAfterTimeout(afterTimeout, k))}
+		}
+	}
+}
+
+func makeAfterTimeout(afterTimeout afterTimeoutFunc, k cid.Cid) func() {
+	return func() { afterTimeout(k) }
+}
+
+func (lt *latencyTracker) CheckDuration(key cid.Cid) (time.Duration, bool) {
+	request, ok := lt.requests[key]
+	var latency time.Duration
+	if ok {
+		latency = time.Now().Sub(request.startedAt)
+	}
+	return latency, ok
+}
+
+func (lt *latencyTracker) RecordResponse(key cid.Cid) (time.Duration, bool) {
+	request, ok := lt.requests[key]
+	var latency time.Duration
+	if ok {
+		latency = time.Now().Sub(request.startedAt)
+		request.timeoutFunc.Stop()
+		delete(lt.requests, key)
+	}
+	return latency, ok
+}
+
+func (lt *latencyTracker) Shutdown() {
+	for _, request := range lt.requests {
+		request.timeoutFunc.Stop()
+	}
+}

--- a/sessionpeermanager/latencytracker.go
+++ b/sessionpeermanager/latencytracker.go
@@ -1,6 +1,7 @@
 package sessionpeermanager
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -48,7 +49,9 @@ func (lt *latencyTracker) CheckDuration(key cid.Cid) (time.Duration, bool) {
 }
 
 func (lt *latencyTracker) RecordResponse(key cid.Cid) (time.Duration, bool) {
+	fmt.Printf("incoming cid: %s\n", key.String())
 	request, ok := lt.requests[key]
+
 	var latency time.Duration
 	if ok {
 		latency = time.Now().Sub(request.startedAt)

--- a/sessionpeermanager/latencytracker.go
+++ b/sessionpeermanager/latencytracker.go
@@ -1,7 +1,6 @@
 package sessionpeermanager
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -49,7 +48,6 @@ func (lt *latencyTracker) CheckDuration(key cid.Cid) (time.Duration, bool) {
 }
 
 func (lt *latencyTracker) RecordResponse(key cid.Cid) (time.Duration, bool) {
-	fmt.Printf("incoming cid: %s\n", key.String())
 	request, ok := lt.requests[key]
 
 	var latency time.Duration

--- a/sessionpeermanager/peerdata.go
+++ b/sessionpeermanager/peerdata.go
@@ -1,0 +1,41 @@
+package sessionpeermanager
+
+import (
+	"time"
+
+	"github.com/ipfs/go-cid"
+)
+
+const (
+	newLatencyWeight = 0.5
+)
+
+type peerData struct {
+	hasLatency bool
+	latency    time.Duration
+	lt         *latencyTracker
+}
+
+func newPeerData() *peerData {
+	return &peerData{
+		hasLatency: false,
+		lt:         newLatencyTracker(),
+		latency:    0,
+	}
+}
+
+func (pd *peerData) AdjustLatency(k cid.Cid, hasFallbackLatency bool, fallbackLatency time.Duration) {
+
+	latency, hasLatency := pd.lt.RecordResponse(k)
+	if !hasLatency {
+		latency, hasLatency = fallbackLatency, hasFallbackLatency
+	}
+	if hasLatency {
+		if pd.hasLatency {
+			pd.latency = time.Duration(float64(pd.latency)*(1.0-newLatencyWeight) + float64(latency)*newLatencyWeight)
+		} else {
+			pd.latency = latency
+			pd.hasLatency = true
+		}
+	}
+}

--- a/sessionpeermanager/peerdata.go
+++ b/sessionpeermanager/peerdata.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	newLatencyWeight = 0.5
+	newLatencyWeight = 0.3
 )
 
 type peerData struct {

--- a/sessionpeermanager/peerdata.go
+++ b/sessionpeermanager/peerdata.go
@@ -1,6 +1,7 @@
 package sessionpeermanager
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -28,12 +29,16 @@ func (pd *peerData) AdjustLatency(k cid.Cid, hasFallbackLatency bool, fallbackLa
 
 	latency, hasLatency := pd.lt.RecordResponse(k)
 	if !hasLatency {
+		if hasFallbackLatency {
+			fmt.Printf("Fallback latency used: %f\n", fallbackLatency.Seconds())
+		}
 		latency, hasLatency = fallbackLatency, hasFallbackLatency
 	}
 	if hasLatency {
 		if pd.hasLatency {
 			pd.latency = time.Duration(float64(pd.latency)*(1.0-newLatencyWeight) + float64(latency)*newLatencyWeight)
 		} else {
+			fmt.Printf("New Latency: %f\n", latency.Seconds())
 			pd.latency = latency
 			pd.hasLatency = true
 		}

--- a/sessionpeermanager/peerdata.go
+++ b/sessionpeermanager/peerdata.go
@@ -33,6 +33,8 @@ func (pd *peerData) AdjustLatency(k cid.Cid, hasFallbackLatency bool, fallbackLa
 			fmt.Printf("Fallback latency used: %f\n", fallbackLatency.Seconds())
 		}
 		latency, hasLatency = fallbackLatency, hasFallbackLatency
+	} else {
+		fmt.Println("Had local latency")
 	}
 	if hasLatency {
 		if pd.hasLatency {

--- a/sessionpeermanager/peerdata.go
+++ b/sessionpeermanager/peerdata.go
@@ -1,7 +1,6 @@
 package sessionpeermanager
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -29,18 +28,12 @@ func (pd *peerData) AdjustLatency(k cid.Cid, hasFallbackLatency bool, fallbackLa
 
 	latency, hasLatency := pd.lt.RecordResponse(k)
 	if !hasLatency {
-		if hasFallbackLatency {
-			fmt.Printf("Fallback latency used: %f\n", fallbackLatency.Seconds())
-		}
 		latency, hasLatency = fallbackLatency, hasFallbackLatency
-	} else {
-		fmt.Println("Had local latency")
 	}
 	if hasLatency {
 		if pd.hasLatency {
 			pd.latency = time.Duration(float64(pd.latency)*(1.0-newLatencyWeight) + float64(latency)*newLatencyWeight)
 		} else {
-			fmt.Printf("New Latency: %f\n", latency.Seconds())
 			pd.latency = latency
 			pd.hasLatency = true
 		}

--- a/sessionpeermanager/sessionpeermanager.go
+++ b/sessionpeermanager/sessionpeermanager.go
@@ -6,8 +6,8 @@ import (
 	"math/rand"
 	"sort"
 
-	logging "github.com/ipfs/go-log"
 	bssd "github.com/ipfs/go-bitswap/sessiondata"
+	logging "github.com/ipfs/go-log"
 
 	cid "github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p-peer"

--- a/sessionpeermanager/sessionpeermanager.go
+++ b/sessionpeermanager/sessionpeermanager.go
@@ -56,8 +56,8 @@ type SessionPeerManager struct {
 func New(ctx context.Context, id uint64, tagger PeerTagger, providerFinder PeerProviderFinder) *SessionPeerManager {
 	spm := &SessionPeerManager{
 		ctx:              ctx,
-		tagger:         tagger,
-		providerFinder: providerFinder,
+		tagger:           tagger,
+		providerFinder:   providerFinder,
 		peerMessages:     make(chan peerMessage, 16),
 		activePeers:      make(map[peer.ID]*peerData),
 		broadcastLatency: newLatencyTracker(),
@@ -72,7 +72,6 @@ func New(ctx context.Context, id uint64, tagger PeerTagger, providerFinder PeerP
 // RecordPeerResponse records that a peer received a block, and adds to it
 // the list of peers if it wasn't already added
 func (spm *SessionPeerManager) RecordPeerResponse(p peer.ID, k cid.Cid) {
-
 	// at the moment, we're just adding peers here
 	// in the future, we'll actually use this to record metrics
 	select {

--- a/sessionrequestsplitter/sessionrequestsplitter.go
+++ b/sessionrequestsplitter/sessionrequestsplitter.go
@@ -2,6 +2,8 @@ package sessionrequestsplitter
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"math/rand"
 
 	bssd "github.com/ipfs/go-bitswap/sessiondata"
@@ -152,6 +154,15 @@ func (s *splitRequestMessage) handle(srs *SessionRequestSplitter) {
 	// first iteration ignore optimization ratings
 	peers := srs.peersFromOptimizedPeers(s.optimizedPeers)
 	ks := s.ks
+	bytes, err := json.Marshal(s.optimizedPeers)
+	if err != nil {
+		fmt.Println("Unable to marshal!")
+	} else {
+		fmt.Printf("OptimizedPeers: %s\n", string(bytes))
+	}
+	fmt.Printf("Split factor: %d\n", split)
+	fmt.Printf("# Peers: %d\n", len(peers))
+	fmt.Printf("# Keys: %d\n", len(ks))
 	if len(peers) < split {
 		split = len(peers)
 	}

--- a/sessionrequestsplitter/sessionrequestsplitter.go
+++ b/sessionrequestsplitter/sessionrequestsplitter.go
@@ -2,7 +2,6 @@ package sessionrequestsplitter
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 
 	bssd "github.com/ipfs/go-bitswap/sessiondata"
@@ -98,30 +97,34 @@ func (srs *SessionRequestSplitter) duplicateRatio() float64 {
 	return float64(srs.duplicateReceivedCount) / float64(srs.receivedCount)
 }
 
+func transformOptimization(optimizationRating float64) float64 {
+	return optimizationRating * optimizationRating * optimizationRating
+}
+
 func (srs *SessionRequestSplitter) peersFromOptimizedPeers(optimizedPeers []bssd.OptimizedPeer) []peer.ID {
 	optimizationTotal := 0.0
 	skipMap := make([]int, len(optimizedPeers))
 	for i, optimizedPeer := range optimizedPeers {
-		optimizationTotal += optimizedPeer.OptimizationRating
+		optimizationTotal += transformOptimization(optimizedPeer.OptimizationRating)
 		skipMap[i] = i + 1
 	}
 	peers := make([]peer.ID, 0, len(optimizedPeers))
 	skipMapStart := 0
-	fmt.Printf("%d\n", len(optimizedPeers))
+	//fmt.Printf("%d\n", len(optimizedPeers))
 	for range optimizedPeers {
 		randValue := rand.Float64()
 		randTarget := randValue * optimizationTotal
-		fmt.Printf("opt total %f, rand %f, randTarget %f\n", optimizationTotal, randValue, randTarget)
-		fmt.Printf("skipMapStart %d\n", skipMapStart)
+		//fmt.Printf("opt total %f, rand %f, randTarget %f\n", optimizationTotal, randValue, randTarget)
+		//fmt.Printf("skipMapStart %d\n", skipMapStart)
 		targetSoFar := 0.0
 		currentIndex := skipMapStart
 		previousIndex := -1
 		for {
-			currentRating := optimizedPeers[currentIndex].OptimizationRating
+			currentRating := transformOptimization(optimizedPeers[currentIndex].OptimizationRating)
 			targetSoFar += currentRating
-			fmt.Printf("targetSoFar %f, randTarget %f\n", targetSoFar, randTarget)
+			//fmt.Printf("targetSoFar %f, randTarget %f\n", targetSoFar, randTarget)
 			if targetSoFar+0.000001 >= randTarget {
-				fmt.Printf("%d\n", currentIndex)
+				//fmt.Printf("%d\n", currentIndex)
 				peers = append(peers, optimizedPeers[currentIndex].Peer)
 				optimizationTotal -= currentRating
 				if currentIndex == skipMapStart {

--- a/sessionrequestsplitter/sessionrequestsplitter.go
+++ b/sessionrequestsplitter/sessionrequestsplitter.go
@@ -160,6 +160,12 @@ func (s *splitRequestMessage) handle(srs *SessionRequestSplitter) {
 	} else {
 		fmt.Printf("OptimizedPeers: %s\n", string(bytes))
 	}
+	bytes, err = json.Marshal(ks)
+	if err != nil {
+		fmt.Println("Unable to marshal!")
+	} else {
+		fmt.Printf("Keys Requested: %s\n", string(bytes))
+	}
 	fmt.Printf("Split factor: %d\n", split)
 	fmt.Printf("# Peers: %d\n", len(peers))
 	fmt.Printf("# Keys: %d\n", len(ks))

--- a/sessionrequestsplitter/sessionrequestsplitter.go
+++ b/sessionrequestsplitter/sessionrequestsplitter.go
@@ -100,7 +100,7 @@ func (srs *SessionRequestSplitter) duplicateRatio() float64 {
 }
 
 func transformOptimization(optimizationRating float64) float64 {
-	return optimizationRating * optimizationRating * optimizationRating
+	return optimizationRating * optimizationRating * optimizationRating * optimizationRating * optimizationRating
 }
 
 func (srs *SessionRequestSplitter) peersFromOptimizedPeers(optimizedPeers []bssd.OptimizedPeer) []peer.ID {
@@ -168,7 +168,7 @@ func (s *splitRequestMessage) handle(srs *SessionRequestSplitter) {
 	}
 	fmt.Printf("Split factor: %d\n", split)
 	fmt.Printf("# Peers: %d\n", len(peers))
-	fmt.Printf("# Keys: %d\n", len(ks))
+	fmt.Printf("# Keys: %d\n\n", len(ks))
 	if len(peers) < split {
 		split = len(peers)
 	}

--- a/sessionrequestsplitter/sessionrequestsplitter.go
+++ b/sessionrequestsplitter/sessionrequestsplitter.go
@@ -2,8 +2,6 @@ package sessionrequestsplitter
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"math/rand"
 
 	bssd "github.com/ipfs/go-bitswap/sessiondata"
@@ -154,21 +152,7 @@ func (s *splitRequestMessage) handle(srs *SessionRequestSplitter) {
 	// first iteration ignore optimization ratings
 	peers := srs.peersFromOptimizedPeers(s.optimizedPeers)
 	ks := s.ks
-	bytes, err := json.Marshal(s.optimizedPeers)
-	if err != nil {
-		fmt.Println("Unable to marshal!")
-	} else {
-		fmt.Printf("OptimizedPeers: %s\n", string(bytes))
-	}
-	bytes, err = json.Marshal(ks)
-	if err != nil {
-		fmt.Println("Unable to marshal!")
-	} else {
-		fmt.Printf("Keys Requested: %s\n", string(bytes))
-	}
-	fmt.Printf("Split factor: %d\n", split)
-	fmt.Printf("# Peers: %d\n", len(peers))
-	fmt.Printf("# Keys: %d\n\n", len(ks))
+
 	if len(peers) < split {
 		split = len(peers)
 	}

--- a/sessionrequestsplitter/sessionrequestsplitter_test.go
+++ b/sessionrequestsplitter/sessionrequestsplitter_test.go
@@ -7,14 +7,16 @@ import (
 	"github.com/ipfs/go-bitswap/testutil"
 )
 
+func quadEaseOut(t float64) float64 { return t * t }
+
 func TestSplittingRequests(t *testing.T) {
 	ctx := context.Background()
-	peers := testutil.GeneratePeers(10)
+	optimizedPeers := testutil.GenerateOptimizedPeers(10, 5, quadEaseOut)
 	keys := testutil.GenerateCids(6)
 
 	srs := New(ctx)
 
-	partialRequests := srs.SplitRequest(peers, keys)
+	partialRequests := srs.SplitRequest(optimizedPeers, keys)
 	if len(partialRequests) != 2 {
 		t.Fatal("Did not generate right number of partial requests")
 	}
@@ -27,12 +29,12 @@ func TestSplittingRequests(t *testing.T) {
 
 func TestSplittingRequestsTooFewKeys(t *testing.T) {
 	ctx := context.Background()
-	peers := testutil.GeneratePeers(10)
+	optimizedPeers := testutil.GenerateOptimizedPeers(10, 5, quadEaseOut)
 	keys := testutil.GenerateCids(1)
 
 	srs := New(ctx)
 
-	partialRequests := srs.SplitRequest(peers, keys)
+	partialRequests := srs.SplitRequest(optimizedPeers, keys)
 	if len(partialRequests) != 1 {
 		t.Fatal("Should only generate as many requests as keys")
 	}
@@ -45,12 +47,12 @@ func TestSplittingRequestsTooFewKeys(t *testing.T) {
 
 func TestSplittingRequestsTooFewPeers(t *testing.T) {
 	ctx := context.Background()
-	peers := testutil.GeneratePeers(1)
+	optimizedPeers := testutil.GenerateOptimizedPeers(1, 1, quadEaseOut)
 	keys := testutil.GenerateCids(6)
 
 	srs := New(ctx)
 
-	partialRequests := srs.SplitRequest(peers, keys)
+	partialRequests := srs.SplitRequest(optimizedPeers, keys)
 	if len(partialRequests) != 1 {
 		t.Fatal("Should only generate as many requests as peers")
 	}
@@ -63,7 +65,7 @@ func TestSplittingRequestsTooFewPeers(t *testing.T) {
 
 func TestSplittingRequestsIncreasingSplitDueToDupes(t *testing.T) {
 	ctx := context.Background()
-	peers := testutil.GeneratePeers(maxSplit)
+	optimizedPeers := testutil.GenerateOptimizedPeers(maxSplit, maxSplit, quadEaseOut)
 	keys := testutil.GenerateCids(maxSplit)
 
 	srs := New(ctx)
@@ -72,7 +74,7 @@ func TestSplittingRequestsIncreasingSplitDueToDupes(t *testing.T) {
 		srs.RecordDuplicateBlock()
 	}
 
-	partialRequests := srs.SplitRequest(peers, keys)
+	partialRequests := srs.SplitRequest(optimizedPeers, keys)
 	if len(partialRequests) != maxSplit {
 		t.Fatal("Did not adjust split up as duplicates came in")
 	}
@@ -80,7 +82,7 @@ func TestSplittingRequestsIncreasingSplitDueToDupes(t *testing.T) {
 
 func TestSplittingRequestsDecreasingSplitDueToNoDupes(t *testing.T) {
 	ctx := context.Background()
-	peers := testutil.GeneratePeers(maxSplit)
+	optimizedPeers := testutil.GenerateOptimizedPeers(maxSplit, maxSplit, quadEaseOut)
 	keys := testutil.GenerateCids(maxSplit)
 
 	srs := New(ctx)
@@ -89,7 +91,7 @@ func TestSplittingRequestsDecreasingSplitDueToNoDupes(t *testing.T) {
 		srs.RecordUniqueBlock()
 	}
 
-	partialRequests := srs.SplitRequest(peers, keys)
+	partialRequests := srs.SplitRequest(optimizedPeers, keys)
 	if len(partialRequests) != 1 {
 		t.Fatal("Did not adjust split down as unique blocks came in")
 	}

--- a/testnet/virtual.go
+++ b/testnet/virtual.go
@@ -223,6 +223,7 @@ type messagePasser struct {
 }
 
 func (mp *messagePasser) SendMsg(ctx context.Context, m bsmsg.BitSwapMessage) error {
+	//fmt.Printf("Message send from: %s\n\n", mp.net.local.String())
 	return mp.net.SendMessage(ctx, mp.target, m)
 }
 
@@ -231,6 +232,7 @@ func (mp *messagePasser) Close() error {
 }
 
 func (mp *messagePasser) Reset() error {
+
 	return nil
 }
 

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 
 	bsmsg "github.com/ipfs/go-bitswap/message"
+	bssd "github.com/ipfs/go-bitswap/sessiondata"
 	"github.com/ipfs/go-bitswap/wantlist"
 	"github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
@@ -74,6 +75,24 @@ func GeneratePeers(n int) []peer.ID {
 		peerIds = append(peerIds, p)
 	}
 	return peerIds
+}
+
+// GenerateOptimizedPeers creates n peer ids,
+// with optimization fall off up to optCount, curveFunc to scale it
+func GenerateOptimizedPeers(n int, optCount int, curveFunc func(float64) float64) []bssd.OptimizedPeer {
+	peers := GeneratePeers(n)
+	optimizedPeers := make([]bssd.OptimizedPeer, 0, n)
+	for i, peer := range peers {
+		var optimizationRating float64
+		if i <= optCount {
+			optimizationRating = 1.0 - float64(i)/float64(optCount)
+		} else {
+			optimizationRating = 0.0
+		}
+		optimizationRating = curveFunc(optimizationRating)
+		optimizedPeers = append(optimizedPeers, bssd.OptimizedPeer{Peer: peer, OptimizationRating: optimizationRating})
+	}
+	return optimizedPeers
 }
 
 var nextSession uint64


### PR DESCRIPTION
# Goals

Further optimize sessions with enhanced peer management and request splitting behavior

# Implementation

1. Further hone peer management by tracking latency on a per peer basis. Record when a request starts and when it ends, and use it to calculate a peers latency based on it.

2. Also pass optimization rating, based on latency, over to request splitter to be used to split requests more effectively

To do:

Utilize request splitter to split requests more effectively