### PR TITLE
fix(sessions): explicitly connect found peers

### DIFF
--- a/bitswap_with_sessions_test.go
+++ b/bitswap_with_sessions_test.go
@@ -152,6 +152,46 @@ func TestSessionSplitFetch(t *testing.T) {
 	}
 }
 
+func TestFetchNotConnected(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	vnet := getVirtualNetwork()
+	sesgen := NewTestSessionGenerator(vnet)
+	defer sesgen.Close()
+	bgen := blocksutil.NewBlockGenerator()
+
+	other := sesgen.Next()
+
+	blks := bgen.Blocks(10)
+	for _, block := range blks {
+		if err := other.Exchange.HasBlock(block); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var cids []cid.Cid
+	for _, blk := range blks {
+		cids = append(cids, blk.Cid())
+	}
+
+	thisNode := sesgen.Next()
+	ses := thisNode.Exchange.NewSession(ctx).(*bssession.Session)
+	ses.SetBaseTickDelay(time.Millisecond * 10)
+
+	ch, err := ses.GetBlocks(ctx, cids)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got []blocks.Block
+	for b := range ch {
+		got = append(got, b)
+	}
+	if err := assertBlockLists(got, blks); err != nil {
+		t.Fatal(err)
+	}
+}
 func TestInterestCacheOverflow(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/bitswap_with_sessions_test.go
+++ b/bitswap_with_sessions_test.go
@@ -156,6 +156,7 @@ func TestFetchNotConnected(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
+	bssession.SetProviderSearchDelay(10 * time.Millisecond)
 	vnet := getVirtualNetwork()
 	sesgen := NewTestSessionGenerator(vnet)
 	defer sesgen.Close()

--- a/session/session.go
+++ b/session/session.go
@@ -222,7 +222,7 @@ func (s *Session) SetBaseTickDelay(baseTickDelay time.Duration) {
 	}
 }
 
-const provSearchDelay = time.Second * 10
+const provSearchDelay = time.Second
 
 // Session run loop -- everything function below here should not be called
 // of this loop

--- a/session/session.go
+++ b/session/session.go
@@ -222,7 +222,12 @@ func (s *Session) SetBaseTickDelay(baseTickDelay time.Duration) {
 	}
 }
 
-const provSearchDelay = time.Second
+var provSearchDelay = time.Second
+
+// SetProviderSearchDelay overwrites the global provider search delay
+func SetProviderSearchDelay(newProvSearchDelay time.Duration) {
+	provSearchDelay = newProvSearchDelay
+}
 
 // Session run loop -- everything function below here should not be called
 // of this loop

--- a/sessionpeermanager/sessionpeermanager.go
+++ b/sessionpeermanager/sessionpeermanager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"sync"
 
 	logging "github.com/ipfs/go-log"
 
@@ -107,11 +106,8 @@ func (spm *SessionPeerManager) FindMorePeers(ctx context.Context, c cid.Cid) {
 		// - manage timeouts
 		// - ensure two 'findprovs' calls for the same block don't run concurrently
 		// - share peers between sessions based on interest set
-		wg := &sync.WaitGroup{}
 		for p := range spm.network.FindProvidersAsync(ctx, k, 10) {
-			wg.Add(1)
 			go func(p peer.ID) {
-				defer wg.Done()
 				err := spm.network.ConnectTo(ctx, p)
 				if err != nil {
 					log.Debugf("failed to connect to provider %s: %s", p, err)
@@ -119,7 +115,6 @@ func (spm *SessionPeerManager) FindMorePeers(ctx context.Context, c cid.Cid) {
 				spm.peerMessages <- &peerFoundMessage{p}
 			}(p)
 		}
-		wg.Wait()
 	}(c)
 }
 

--- a/sessionpeermanager/sessionpeermanager.go
+++ b/sessionpeermanager/sessionpeermanager.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sync"
+
+	logging "github.com/ipfs/go-log"
 
 	cid "github.com/ipfs/go-cid"
 	ifconnmgr "github.com/libp2p/go-libp2p-interface-connmgr"
 	peer "github.com/libp2p/go-libp2p-peer"
 )
+
+var log = logging.Logger("bitswap")
 
 const (
 	maxOptimizedPeers = 32
@@ -18,6 +23,7 @@ const (
 // PeerNetwork is an interface for finding providers and managing connections
 type PeerNetwork interface {
 	ConnectionManager() ifconnmgr.ConnManager
+	ConnectTo(context.Context, peer.ID) error
 	FindProvidersAsync(context.Context, cid.Cid, int) <-chan peer.ID
 }
 
@@ -101,9 +107,19 @@ func (spm *SessionPeerManager) FindMorePeers(ctx context.Context, c cid.Cid) {
 		// - manage timeouts
 		// - ensure two 'findprovs' calls for the same block don't run concurrently
 		// - share peers between sessions based on interest set
+		wg := &sync.WaitGroup{}
 		for p := range spm.network.FindProvidersAsync(ctx, k, 10) {
-			spm.peerMessages <- &peerFoundMessage{p}
+			wg.Add(1)
+			go func(p peer.ID) {
+				defer wg.Done()
+				err := spm.network.ConnectTo(ctx, p)
+				if err != nil {
+					log.Debugf("failed to connect to provider %s: %s", p, err)
+				}
+				spm.peerMessages <- &peerFoundMessage{p}
+			}(p)
 		}
+		wg.Wait()
 	}(c)
 }
 

--- a/sessionpeermanager/sessionpeermanager_test.go
+++ b/sessionpeermanager/sessionpeermanager_test.go
@@ -2,8 +2,8 @@ package sessionpeermanager
 
 import (
 	"context"
-	"sync"
 	"math/rand"
+	"sync"
 	"testing"
 	"time"
 
@@ -22,6 +22,10 @@ type fakePeerNetwork struct {
 
 func (fpn *fakePeerNetwork) ConnectionManager() ifconnmgr.ConnManager {
 	return fpn.connManager
+}
+
+func (fpn *fakePeerNetwork) ConnectTo(context.Context, peer.ID) error {
+	return nil
 }
 
 func (fpn *fakePeerNetwork) FindProvidersAsync(ctx context.Context, c cid.Cid, num int) <-chan peer.ID {


### PR DESCRIPTION
# Goal

When providers are found in a session, explicitly connect them so they get added to the peer manager
fix #53

# Implementation

- For now, copy the code that is used by the providerQueryWorker to connect newly found providers (this will be removed when we address #52)
- Add a test which demonstrates the failing case for this behavior (fetching blocks from a peer that is not already connected), and verify changes resolve it

# For Discussion

n/a