### PR TITLE
WIP: Feat/logging and docs

### DIFF
--- a/decision/engine.go
+++ b/decision/engine.go
@@ -6,12 +6,12 @@ import (
 	"sync"
 	"time"
 
+	bslog "github.com/ipfs/go-bitswap/log"
 	bsmsg "github.com/ipfs/go-bitswap/message"
 	wl "github.com/ipfs/go-bitswap/wantlist"
 
 	blocks "github.com/ipfs/go-block-format"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
-	logging "github.com/ipfs/go-log"
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
@@ -47,7 +47,7 @@ import (
 // whatever it sees fit to produce desired outcomes (get wanted keys
 // quickly, maintain good relationships with peers, etc).
 
-var log = logging.Logger("engine")
+var log = bslog.Logger("engine")
 
 const (
 	// outboxChanBuffer must be 0 to prevent stale messages from being sent

--- a/docs/bitswap_activity_diagram.puml
+++ b/docs/bitswap_activity_diagram.puml
@@ -1,0 +1,88 @@
+@startuml Bitswap Activity Diagram
+start
+:Bitswap initialized;
+fork
+  :WantManager initialized;
+  repeat
+    :Wait for incoming wants;
+    :Calculate wantlist changes;
+    :Send changes to PeerManager;
+    if (changes target to specific peers?) then (yes)
+      :Filter targets for those that are in the peer manager;
+    else (no)
+      :Use all peers in peermanager (broadcast);
+    endif
+    fork
+      :MessageQueue for peer queues up 
+       changes till last message done sending;
+      :MessageQueue initializes peer connection if not initialized;
+      repeat
+        :Attempt to send message;
+        if (message send failed?) then (yes)
+          :Attempt to reconnect peer;
+        else (no)
+        endif 
+      repeat while (send successful or failure to reconnect?) is (no)
+    fork again
+      :MessageQueue for peer queues up 
+       changes till last message done sending;
+      :MessageQueue initializes peer connection if not initialized;
+      repeat
+        :Attempt to send message;
+        if (message send failed?) then (yes)
+          :Attempt to reconnect peer;
+        else (no)
+        endif
+      repeat while (send successful or failure to reconnect?) is (no)
+    end fork
+  repeat while (bitswap is open?) is (yes)
+fork again
+  :Bitswap sets network's receiver to itself;
+  repeat
+    :Wait to receive new blocks from network;
+    :Notify global bitswap notifier blocks received;
+    :Send blocks to interested sessions;
+  repeat while (bitswap is open?) is (yes)
+fork again
+:Session created with NewSession;
+fork
+  while (session is open?) is (yes)
+    if (has block requests?) then (yes)
+      if (has session peers?) then (yes)
+        :Make targeted request for more blocks to WantManager;
+      else (no)
+        :Make broadcase request for more blocks to WantManager;
+      endif 
+      if (receives blocks before provSearchDelay or tick) then (yes)
+        :SessionPeerManager records peers that received;
+        :Notify GetBlocks that blocks were received;
+      else (no)
+        :Rebroadcast current blocks;
+        :Look for providers with FindProvidersAsync;
+        :Connect to providers with ConnectTo;
+        :Bitswap.PeerConnected called;
+        :PeerManager.Connected called;
+        :New MessageQueue created for peer;
+        :Broadcast Wantlist Sent To Peer;
+      endif;
+    else (no)
+    endif;
+  endwhile (no);
+fork again
+  :GetBlocks called for session;
+  :Send block requests to session;
+  fork
+    :Return incoming blocks channel;
+  fork again
+    while (all blocks received?) is (no)
+      :Wait to be notified of blocks received;
+      :Push received blocks to incoming blocks channel;
+    endwhile (yes)
+    :Close incoming blocks channel;
+  end fork
+  stop
+end fork
+stop
+end fork
+end
+@enduml

--- a/getter/getter.go
+++ b/getter/getter.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"errors"
 
+	bslog "github.com/ipfs/go-bitswap/log"
 	notifications "github.com/ipfs/go-bitswap/notifications"
-	logging "github.com/ipfs/go-log"
 
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 )
 
-var log = logging.Logger("bitswap")
+var log = bslog.Logger("bitswap")
 
 // GetBlocksFunc is any function that can take an array of CIDs and return a
 // channel of incoming blocks.
@@ -73,7 +73,7 @@ func AsyncGetBlocks(ctx context.Context, keys []cid.Cid, notif notifications.Pub
 	remaining := cid.NewSet()
 	promise := notif.Subscribe(ctx, keys...)
 	for _, k := range keys {
-		log.Event(ctx, "Bitswap.GetBlockRequest.Start", k)
+		log.LogKV(ctx, "Bitswap.GetBlockRequest.Start", k)
 		remaining.Add(k)
 	}
 
@@ -100,6 +100,7 @@ func handleIncoming(ctx context.Context, remaining *cid.Set, in <-chan blocks.Bl
 			}
 
 			remaining.Remove(blk.Cid())
+			log.LogKV(ctx, "Bitswap.GetBlockRequest.End", blk.Cid())
 			select {
 			case out <- blk:
 			case <-ctx.Done():

--- a/log/log.go
+++ b/log/log.go
@@ -34,6 +34,9 @@ func Logger(name string) logging.EventLogger {
 	}
 	// this is a terrible hack to get at the underlying
 	// go-logging logger if present to set the call depth
+	// so file lines print correctly
+	// it uses way more of the reflect api that one should ever
+	// have access to!
 	elem := reflect.ValueOf(log).Elem()
 	typeOfT := elem.Type()
 FieldIteration:
@@ -136,6 +139,7 @@ func (lw *bsLogWrapper) LogKV(ctx context.Context, alternatingKeyValues ...inter
 		lw.internalLog.Errorf("LogKV with no Span in context called on %s:%d", path.Base(file), line)
 		return
 	}
+	metadata = logging.DeepMerge(logging.Metadata(make(map[string]interface{})), metadata)
 	for i := 0; i*2 < len(alternatingKeyValues); i++ {
 		key := alternatingKeyValues[i*2].(string)
 		metadata[key] = alternatingKeyValues[i*2+1]

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,193 @@
+package log
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path"
+	"runtime"
+
+	logging "github.com/ipfs/go-log"
+	"github.com/libp2p/go-libp2p-loggables"
+	goLogging "github.com/whyrusleeping/go-logging"
+)
+
+const (
+	envLogTraces = "IPFS_BITSWAP_LOG_TRACES"
+)
+
+// Logger returns a logger for bitswap compatible with go-log EventLogger
+// interface.
+// In normal instances, it simply calls go-log's Logger constructor
+// However, it can also return a wrapped logger that outputs tracing calls
+// directly into regular logs.
+// The specific purpose of this is the desire to integrate tracing into
+// Bitswap while also aware there deployments which lack the infrastructure
+// to make tracing useful, and we want to product comprehensible log messages
+// instead
+func Logger(name string) logging.EventLogger {
+
+	log := logging.Logger(name)
+	if os.Getenv(envLogTraces) == "" {
+		return log
+	}
+	goLoggingLogger, ok := log.(logging.StandardLogger).(*goLogging.Logger)
+	if ok {
+		goLoggingLogger.ExtraCalldepth = 1
+	}
+	return &bsLogWrapper{
+		internalLog: log,
+	}
+}
+
+type bsLogWrapper struct {
+	internalLog logging.EventLogger
+}
+
+func (lw *bsLogWrapper) Debug(args ...interface{}) {
+	lw.internalLog.Debug(args...)
+}
+
+func (lw *bsLogWrapper) Debugf(format string, args ...interface{}) {
+	lw.internalLog.Debugf(format, args...)
+}
+
+func (lw *bsLogWrapper) Error(args ...interface{}) {
+	lw.internalLog.Error(args...)
+}
+
+func (lw *bsLogWrapper) Errorf(format string, args ...interface{}) {
+	lw.internalLog.Errorf(format, args...)
+}
+
+func (lw *bsLogWrapper) Fatal(args ...interface{}) {
+	lw.internalLog.Fatal(args...)
+}
+
+func (lw *bsLogWrapper) Fatalf(format string, args ...interface{}) {
+	lw.internalLog.Fatalf(format, args...)
+}
+
+func (lw *bsLogWrapper) Info(args ...interface{}) {
+	lw.internalLog.Info(args...)
+}
+
+func (lw *bsLogWrapper) Infof(format string, args ...interface{}) {
+	lw.internalLog.Infof(format, args...)
+}
+
+func (lw *bsLogWrapper) Panic(args ...interface{}) {
+	lw.internalLog.Panic(args...)
+}
+
+func (lw *bsLogWrapper) Panicf(format string, args ...interface{}) {
+	lw.internalLog.Panicf(format, args...)
+}
+
+func (lw *bsLogWrapper) Warning(args ...interface{}) {
+	lw.internalLog.Warning(args...)
+}
+
+func (lw *bsLogWrapper) Warningf(format string, args ...interface{}) {
+	lw.internalLog.Warningf(format, args...)
+}
+
+func (lw *bsLogWrapper) Start(ctx context.Context, name string) context.Context {
+	newLoggable := loggables.Uuid(name)
+	return logging.ContextWithLoggable(ctx, newLoggable)
+}
+
+func (lw *bsLogWrapper) StartFromParentState(ctx context.Context, name string, parent []byte) (context.Context, error) {
+	metadata := logging.Metadata(make(map[string]interface{}))
+	err := json.Unmarshal(parent, &metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	newLoggable := loggables.Uuid(name)
+	mergedLoggable := logging.DeepMerge(metadata, logging.Metadata(newLoggable.Loggable()))
+	return logging.ContextWithLoggable(ctx, mergedLoggable), nil
+}
+
+func (lw *bsLogWrapper) SerializeContext(ctx context.Context) ([]byte, error) {
+	metadata, err := logging.MetadataFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(metadata)
+}
+
+func (lw *bsLogWrapper) LogKV(ctx context.Context, alternatingKeyValues ...interface{}) {
+	metadata, err := logging.MetadataFromContext(ctx)
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		lw.internalLog.Errorf("LogKV with no Span in context called on %s:%d", path.Base(file), line)
+		return
+	}
+	for i := 0; i*2 < len(alternatingKeyValues); i++ {
+		key := alternatingKeyValues[i*2].(string)
+		metadata[key] = alternatingKeyValues[i*2+1]
+	}
+	logMessage, err := metadata.JsonString()
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		lw.internalLog.Errorf("LogKV -- error serializing message", path.Base(file), line)
+		return
+	}
+	lw.internalLog.Debug(logMessage)
+}
+
+func (lw *bsLogWrapper) SetTag(ctx context.Context, k string, v interface{}) {
+	metadata, err := logging.MetadataFromContext(ctx)
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		lw.internalLog.Errorf("SetTag with no Span in context called on %s:%d", path.Base(file), line)
+		return
+	}
+	metadata[k] = v
+}
+
+func (lw *bsLogWrapper) SetTags(ctx context.Context, tags map[string]interface{}) {
+	metadata, err := logging.MetadataFromContext(ctx)
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		lw.internalLog.Errorf("SetTags with no Span in context called on %s:%d", path.Base(file), line)
+		return
+	}
+	for k, v := range tags {
+		metadata[k] = v
+	}
+}
+
+func (lw *bsLogWrapper) setErr(ctx context.Context, err error, skip int) {
+	_, merr := logging.MetadataFromContext(ctx)
+	if merr != nil {
+		_, file, line, _ := runtime.Caller(skip)
+		lw.internalLog.Errorf("SetErr with no Span in context called on %s:%d", path.Base(file), line)
+		return
+	}
+	if err == nil {
+		return
+	}
+	lw.LogKV(ctx, "error", err.Error())
+}
+
+func (lw *bsLogWrapper) SetErr(ctx context.Context, err error) {
+	lw.setErr(ctx, err, 1)
+}
+
+func (lw *bsLogWrapper) FinishWithErr(ctx context.Context, err error) {
+	lw.setErr(ctx, err, 2)
+}
+
+func (lw *bsLogWrapper) Finish(ctx context.Context) {
+}
+
+func (lw *bsLogWrapper) Event(ctx context.Context, event string, m ...logging.Loggable) {
+	lw.internalLog.Panicf("Do Not Use Deprecated Event Method")
+}
+
+func (lw *bsLogWrapper) EventBegin(ctx context.Context, event string, m ...logging.Loggable) *logging.EventInProgress {
+	lw.internalLog.Panicf("Do Not Use Deprecated EventBegin Method")
+	return nil
+}

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -5,14 +5,14 @@ import (
 	"sync"
 	"time"
 
+	bslog "github.com/ipfs/go-bitswap/log"
 	bsmsg "github.com/ipfs/go-bitswap/message"
 	bsnet "github.com/ipfs/go-bitswap/network"
 	wantlist "github.com/ipfs/go-bitswap/wantlist"
-	logging "github.com/ipfs/go-log"
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
-var log = logging.Logger("bitswap")
+var log = bslog.Logger("bitswap")
 
 // MessageNetwork is any network that can connect peers and generate a message
 // sender.

--- a/network/ipfs_impl.go
+++ b/network/ipfs_impl.go
@@ -8,11 +8,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	bslog "github.com/ipfs/go-bitswap/log"
 	bsmsg "github.com/ipfs/go-bitswap/message"
 
 	ggio "github.com/gogo/protobuf/io"
 	cid "github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log"
 	host "github.com/libp2p/go-libp2p-host"
 	ifconnmgr "github.com/libp2p/go-libp2p-interface-connmgr"
 	inet "github.com/libp2p/go-libp2p-net"
@@ -22,7 +22,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-var log = logging.Logger("bitswap_network")
+var log = bslog.Logger("bitswap_network")
 
 var sendMessageTimeout = time.Minute * 10
 

--- a/package.json
+++ b/package.json
@@ -190,6 +190,12 @@
       "hash": "QmSJ9n2s9NUoA9D849W5jj5SJ94nMcZpj1jCgQJieiNqSt",
       "name": "go-random",
       "version": "1.0.0"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmcaSwFc5RBg8yCq54QURwEU4nwjfCpjbpmaAm4VbdGLKv",
+      "name": "go-logging",
+      "version": "0.0.0"
     }
   ],
   "gxVersion": "0.12.1",

--- a/peermanager/peermanager.go
+++ b/peermanager/peermanager.go
@@ -3,14 +3,14 @@ package peermanager
 import (
 	"context"
 
+	bslog "github.com/ipfs/go-bitswap/log"
 	bsmsg "github.com/ipfs/go-bitswap/message"
 	wantlist "github.com/ipfs/go-bitswap/wantlist"
-	logging "github.com/ipfs/go-log"
 
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
-var log = logging.Logger("bitswap")
+var log = bslog.Logger("bitswap")
 
 var (
 	metricsBuckets = []float64{1 << 6, 1 << 10, 1 << 14, 1 << 18, 1<<18 + 15, 1 << 22}

--- a/sessionmanager/sessionmanager.go
+++ b/sessionmanager/sessionmanager.go
@@ -7,10 +7,13 @@ import (
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 
+	bslog "github.com/ipfs/go-bitswap/log"
 	bssession "github.com/ipfs/go-bitswap/session"
 	exchange "github.com/ipfs/go-ipfs-exchange-interface"
 	peer "github.com/libp2p/go-libp2p-peer"
 )
+
+var log = bslog.Logger("bitswap")
 
 // Session is a session that is managed by the session manager
 type Session interface {

--- a/sessionpeermanager/sessionpeermanager.go
+++ b/sessionpeermanager/sessionpeermanager.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"math/rand"
 
-	logging "github.com/ipfs/go-log"
-
+	bslog "github.com/ipfs/go-bitswap/log"
 	cid "github.com/ipfs/go-cid"
 	ifconnmgr "github.com/libp2p/go-libp2p-interface-connmgr"
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
-var log = logging.Logger("bitswap")
+var log = bslog.Logger("bitswap")
 
 const (
 	maxOptimizedPeers = 32

--- a/testnet/virtual.go
+++ b/testnet/virtual.go
@@ -11,10 +11,10 @@ import (
 	bsmsg "github.com/ipfs/go-bitswap/message"
 	bsnet "github.com/ipfs/go-bitswap/network"
 
+	bslog "github.com/ipfs/go-bitswap/log"
 	cid "github.com/ipfs/go-cid"
 	delay "github.com/ipfs/go-ipfs-delay"
 	mockrouting "github.com/ipfs/go-ipfs-routing/mock"
-	logging "github.com/ipfs/go-log"
 	ifconnmgr "github.com/libp2p/go-libp2p-interface-connmgr"
 	peer "github.com/libp2p/go-libp2p-peer"
 	routing "github.com/libp2p/go-libp2p-routing"
@@ -22,7 +22,7 @@ import (
 	testutil "github.com/libp2p/go-testutil"
 )
 
-var log = logging.Logger("bstestnet")
+var log = bslog.Logger("bstestnet")
 
 func VirtualNetwork(rs mockrouting.Server, d delay.D) Network {
 	return &network{

--- a/wantmanager/wantmanager.go
+++ b/wantmanager/wantmanager.go
@@ -4,16 +4,15 @@ import (
 	"context"
 	"math"
 
+	bslog "github.com/ipfs/go-bitswap/log"
 	bsmsg "github.com/ipfs/go-bitswap/message"
 	wantlist "github.com/ipfs/go-bitswap/wantlist"
-	logging "github.com/ipfs/go-log"
-
 	cid "github.com/ipfs/go-cid"
 	metrics "github.com/ipfs/go-metrics-interface"
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
-var log = logging.Logger("bitswap")
+var log = bslog.Logger("bitswap")
 
 const (
 	// maxPriority is the max priority as defined by the bitswap protocol

--- a/workers.go
+++ b/workers.go
@@ -139,7 +139,7 @@ func (bs *Bitswap) provideWorker(px process.Process) {
 	// worker spawner, reads from bs.provideKeys until it closes, spawning a
 	// _ratelimited_ number of workers to handle each key.
 	for wid := 2; ; wid++ {
-		log.LogKV(procctx.OnClosingContext(px), "Bitswap.ProvideWorker.Loop", true, "ID", 1)
+		log.LogKV(ctx, "Bitswap.ProvideWorker.Loop", true, "ID", 1)
 
 		select {
 		case <-px.Closing():


### PR DESCRIPTION
# Goals

Make Bitswap more pleasant to work with through better logging and some docs that illustrate how it works

# Implementation

- Add a UML activity diagram in PlantUML that tracks the various stages of operations in Bitswap through which it wants & receives blocks in the context of sessions
- Add tracing to bitswap, currently via go-log, but likely to change very soon (before merge)
- Since tracing infrastructure is not yet in place, add a temporary wrapper on go-log to log trace messages as structured json in the regular log (that is conveniently compatible with existing ContextWithLoggable calls in IPFS itself)
- Add logs to sessions that output all of the key events so that you can see when each happens, along with lots of metadata about the session and other things happening in it

# For discussion

WIP - Do not merge - will change as soon https://github.com/ipfs/go-ipfs/issues/5783 gets closer to merge w/ work from @lanzafame  -- not going to use go-log among other things

fix #55 