### PR TITLE
contexts: make sure to abort when a context is canceled

### DIFF
--- a/sessionrequestsplitter/sessionrequestsplitter.go
+++ b/sessionrequestsplitter/sessionrequestsplitter.go
@@ -51,7 +51,7 @@ func New(ctx context.Context) *SessionRequestSplitter {
 // SplitRequest splits a request for the given cids one or more times among the
 // given peers.
 func (srs *SessionRequestSplitter) SplitRequest(peers []peer.ID, ks []cid.Cid) []*PartialRequest {
-	resp := make(chan []*PartialRequest)
+	resp := make(chan []*PartialRequest, 1)
 
 	select {
 	case srs.messages <- &splitRequestMessage{peers, ks, resp}:

--- a/workers.go
+++ b/workers.go
@@ -217,11 +217,15 @@ func (bs *Bitswap) rebroadcastWorker(parent context.Context) {
 			// TODO: come up with a better strategy for determining when to search
 			// for new providers for blocks.
 			i := rand.Intn(len(entries))
-			bs.findKeys <- &blockRequest{
+			select {
+			case bs.findKeys <- &blockRequest{
 				Cid: entries[i].Cid,
 				Ctx: ctx,
+			}:
+			case <-ctx.Done():
+				return
 			}
-		case <-parent.Done():
+		case <-ctx.Done():
 			return
 		}
 	}


### PR DESCRIPTION
Also, buffer single-use channels we may walk away from. This was showing up (rarely) in a go-ipfs test (test/integration.Test1KBInstantaneous).