### PR TITLE
providers: don't add every connected node as a provider

### DIFF
--- a/network/ipfs_impl.go
+++ b/network/ipfs_impl.go
@@ -151,22 +151,7 @@ func (bsnet *impl) ConnectTo(ctx context.Context, p peer.ID) error {
 
 // FindProvidersAsync returns a channel of providers for the given key.
 func (bsnet *impl) FindProvidersAsync(ctx context.Context, k cid.Cid, max int) <-chan peer.ID {
-
-	// Since routing queries are expensive, give bitswap the peers to which we
-	// have open connections. Note that this may cause issues if bitswap starts
-	// precisely tracking which peers provide certain keys. This optimization
-	// would be misleading. In the long run, this may not be the most
-	// appropriate place for this optimization, but it won't cause any harm in
-	// the short term.
-	connectedPeers := bsnet.host.Network().Peers()
-	out := make(chan peer.ID, len(connectedPeers)) // just enough buffer for these connectedPeers
-	for _, id := range connectedPeers {
-		if id == bsnet.host.ID() {
-			continue // ignore self as provider
-		}
-		out <- id
-	}
-
+	out := make(chan peer.ID, max)
 	go func() {
 		defer close(out)
 		providers := bsnet.routing.FindProvidersAsync(ctx, k, max)


### PR DESCRIPTION
We now do exactly what the comment is warning about: track peers providing keys.

NOTE: This should be tested against the live network.