### PR TITLE
Feat: A more robust provider finder for sessions (for now) and soon for all bitswap

### DIFF
--- a/providerquerymanager/providerquerymanager.go
+++ b/providerquerymanager/providerquerymanager.go
@@ -1,0 +1,343 @@
+package providerquerymanager
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+var log = logging.Logger("bitswap")
+
+const (
+	maxProviders         = 10
+	maxInProcessRequests = 6
+)
+
+type inProgressRequestStatus struct {
+	providersSoFar []peer.ID
+	listeners      map[uint64]chan peer.ID
+}
+
+// ProviderQueryNetwork is an interface for finding providers and connecting to
+// peers.
+type ProviderQueryNetwork interface {
+	ConnectTo(context.Context, peer.ID) error
+	FindProvidersAsync(context.Context, cid.Cid, int) <-chan peer.ID
+}
+
+type providerQueryMessage interface {
+	handle(pqm *ProviderQueryManager)
+}
+
+type receivedProviderMessage struct {
+	k cid.Cid
+	p peer.ID
+}
+
+type finishedProviderQueryMessage struct {
+	k cid.Cid
+}
+
+type newProvideQueryMessage struct {
+	ses                   uint64
+	k                     cid.Cid
+	inProgressRequestChan chan<- inProgressRequest
+}
+
+type cancelRequestMessage struct {
+	ses uint64
+	k   cid.Cid
+}
+
+// ProviderQueryManager manages requests to find more providers for blocks
+// for bitswap sessions. It's main goals are to:
+// - rate limit requests -- don't have too many find provider calls running
+// simultaneously
+// - connect to found peers and filter them if it can't connect
+// - ensure two findprovider calls for the same block don't run concurrently
+// TODO:
+// - manage timeouts
+type ProviderQueryManager struct {
+	ctx                   context.Context
+	network               ProviderQueryNetwork
+	providerQueryMessages chan providerQueryMessage
+
+	// do not touch outside the run loop
+	providerRequestsProcessing   chan cid.Cid
+	incomingFindProviderRequests chan cid.Cid
+	inProgressRequestStatuses    map[cid.Cid]*inProgressRequestStatus
+}
+
+// New initializes a new ProviderQueryManager for a given context and a given
+// network provider.
+func New(ctx context.Context, network ProviderQueryNetwork) *ProviderQueryManager {
+	return &ProviderQueryManager{
+		ctx:                          ctx,
+		network:                      network,
+		providerQueryMessages:        make(chan providerQueryMessage, 16),
+		providerRequestsProcessing:   make(chan cid.Cid),
+		incomingFindProviderRequests: make(chan cid.Cid),
+		inProgressRequestStatuses:    make(map[cid.Cid]*inProgressRequestStatus),
+	}
+}
+
+// Startup starts processing for the ProviderQueryManager.
+func (pqm *ProviderQueryManager) Startup() {
+	go pqm.run()
+}
+
+type inProgressRequest struct {
+	providersSoFar []peer.ID
+	incoming       <-chan peer.ID
+}
+
+// FindProvidersAsync finds providers for the given block.
+func (pqm *ProviderQueryManager) FindProvidersAsync(sessionCtx context.Context, k cid.Cid, ses uint64) <-chan peer.ID {
+	inProgressRequestChan := make(chan inProgressRequest)
+
+	select {
+	case pqm.providerQueryMessages <- &newProvideQueryMessage{
+		ses:                   ses,
+		k:                     k,
+		inProgressRequestChan: inProgressRequestChan,
+	}:
+	case <-pqm.ctx.Done():
+		return nil
+	case <-sessionCtx.Done():
+		return nil
+	}
+
+	var receivedInProgressRequest inProgressRequest
+	select {
+	case <-sessionCtx.Done():
+		return nil
+	case receivedInProgressRequest = <-inProgressRequestChan:
+	}
+
+	return pqm.receiveProviders(sessionCtx, k, ses, receivedInProgressRequest)
+}
+
+func (pqm *ProviderQueryManager) receiveProviders(sessionCtx context.Context, k cid.Cid, ses uint64, receivedInProgressRequest inProgressRequest) <-chan peer.ID {
+	// maintains an unbuffered queue for incoming providers for given request for a given session
+	// essentially, as a provider comes in, for a given CID, we want to immediately broadcast to all
+	// sessions that queried that CID, without worrying about whether the client code is actually
+	// reading from the returned channel -- so that the broadcast never blocks
+	// based on: https://medium.com/capital-one-tech/building-an-unbounded-channel-in-go-789e175cd2cd
+	returnedProviders := make(chan peer.ID)
+	receivedProviders := append([]peer.ID(nil), receivedInProgressRequest.providersSoFar[0:]...)
+	incomingProviders := receivedInProgressRequest.incoming
+
+	go func() {
+		defer close(returnedProviders)
+		outgoingProviders := func() chan<- peer.ID {
+			if len(receivedProviders) == 0 {
+				return nil
+			}
+			return returnedProviders
+		}
+		nextProvider := func() peer.ID {
+			if len(receivedProviders) == 0 {
+				return ""
+			}
+			return receivedProviders[0]
+		}
+		for len(receivedProviders) > 0 || incomingProviders != nil {
+			select {
+			case <-sessionCtx.Done():
+				pqm.providerQueryMessages <- &cancelRequestMessage{
+					ses: ses,
+					k:   k,
+				}
+				// clear out any remaining providers
+				for range incomingProviders {
+				}
+				return
+			case provider, ok := <-incomingProviders:
+				if !ok {
+					incomingProviders = nil
+				} else {
+					receivedProviders = append(receivedProviders, provider)
+				}
+			case outgoingProviders() <- nextProvider():
+				receivedProviders = receivedProviders[1:]
+			}
+		}
+	}()
+	return returnedProviders
+}
+
+func (pqm *ProviderQueryManager) findProviderWorker() {
+	// findProviderWorker just cycles through incoming provider queries one
+	// at a time. We have six of these workers running at once
+	// to let requests go in parallel but keep them rate limited
+	for {
+		select {
+		case k, ok := <-pqm.providerRequestsProcessing:
+			if !ok {
+				return
+			}
+
+			providers := pqm.network.FindProvidersAsync(pqm.ctx, k, maxProviders)
+			wg := &sync.WaitGroup{}
+			for p := range providers {
+				wg.Add(1)
+				go func(p peer.ID) {
+					defer wg.Done()
+					err := pqm.network.ConnectTo(pqm.ctx, p)
+					if err != nil {
+						log.Debugf("failed to connect to provider %s: %s", p, err)
+						return
+					}
+					select {
+					case pqm.providerQueryMessages <- &receivedProviderMessage{
+						k: k,
+						p: p,
+					}:
+					case <-pqm.ctx.Done():
+						return
+					}
+				}(p)
+			}
+			wg.Wait()
+			select {
+			case pqm.providerQueryMessages <- &finishedProviderQueryMessage{
+				k: k,
+			}:
+			case <-pqm.ctx.Done():
+			}
+		case <-pqm.ctx.Done():
+			return
+		}
+	}
+}
+
+func (pqm *ProviderQueryManager) providerRequestBufferWorker() {
+	// the provider request buffer worker just maintains an unbounded
+	// buffer for incoming provider queries and dispatches to the find
+	// provider workers as they become available
+	// based on: https://medium.com/capital-one-tech/building-an-unbounded-channel-in-go-789e175cd2cd
+	var providerQueryRequestBuffer []cid.Cid
+	nextProviderQuery := func() cid.Cid {
+		if len(providerQueryRequestBuffer) == 0 {
+			return cid.Cid{}
+		}
+		return providerQueryRequestBuffer[0]
+	}
+	outgoingRequests := func() chan<- cid.Cid {
+		if len(providerQueryRequestBuffer) == 0 {
+			return nil
+		}
+		return pqm.providerRequestsProcessing
+	}
+
+	for {
+		select {
+		case incomingRequest, ok := <-pqm.incomingFindProviderRequests:
+			if !ok {
+				return
+			}
+			providerQueryRequestBuffer = append(providerQueryRequestBuffer, incomingRequest)
+		case outgoingRequests() <- nextProviderQuery():
+			providerQueryRequestBuffer = providerQueryRequestBuffer[1:]
+		case <-pqm.ctx.Done():
+			return
+		}
+	}
+}
+
+func (pqm *ProviderQueryManager) cleanupInProcessRequests() {
+	for _, requestStatus := range pqm.inProgressRequestStatuses {
+		for _, listener := range requestStatus.listeners {
+			close(listener)
+		}
+	}
+}
+
+func (pqm *ProviderQueryManager) run() {
+	defer close(pqm.incomingFindProviderRequests)
+	defer close(pqm.providerRequestsProcessing)
+	defer pqm.cleanupInProcessRequests()
+
+	go pqm.providerRequestBufferWorker()
+	for i := 0; i < maxInProcessRequests; i++ {
+		go pqm.findProviderWorker()
+	}
+
+	for {
+		select {
+		case nextMessage := <-pqm.providerQueryMessages:
+			nextMessage.handle(pqm)
+		case <-pqm.ctx.Done():
+			return
+		}
+	}
+}
+
+func (rpm *receivedProviderMessage) handle(pqm *ProviderQueryManager) {
+	requestStatus, ok := pqm.inProgressRequestStatuses[rpm.k]
+	if !ok {
+		log.Errorf("Received provider (%s) for cid (%s) not requested", rpm.p.String(), rpm.k.String())
+		return
+	}
+	requestStatus.providersSoFar = append(requestStatus.providersSoFar, rpm.p)
+	for _, listener := range requestStatus.listeners {
+		select {
+		case listener <- rpm.p:
+		case <-pqm.ctx.Done():
+			return
+		}
+	}
+}
+
+func (fpqm *finishedProviderQueryMessage) handle(pqm *ProviderQueryManager) {
+	requestStatus, ok := pqm.inProgressRequestStatuses[fpqm.k]
+	if !ok {
+		log.Errorf("Ended request for cid (%s) not in progress", fpqm.k.String())
+		return
+	}
+	for _, listener := range requestStatus.listeners {
+		close(listener)
+	}
+	delete(pqm.inProgressRequestStatuses, fpqm.k)
+}
+
+func (npqm *newProvideQueryMessage) handle(pqm *ProviderQueryManager) {
+	requestStatus, ok := pqm.inProgressRequestStatuses[npqm.k]
+	if !ok {
+		requestStatus = &inProgressRequestStatus{
+			listeners: make(map[uint64]chan peer.ID),
+		}
+		pqm.inProgressRequestStatuses[npqm.k] = requestStatus
+		select {
+		case pqm.incomingFindProviderRequests <- npqm.k:
+		case <-pqm.ctx.Done():
+			return
+		}
+	}
+	requestStatus.listeners[npqm.ses] = make(chan peer.ID)
+	select {
+	case npqm.inProgressRequestChan <- inProgressRequest{
+		providersSoFar: requestStatus.providersSoFar,
+		incoming:       requestStatus.listeners[npqm.ses],
+	}:
+	case <-pqm.ctx.Done():
+	}
+}
+
+func (crm *cancelRequestMessage) handle(pqm *ProviderQueryManager) {
+	requestStatus, ok := pqm.inProgressRequestStatuses[crm.k]
+	if !ok {
+		log.Errorf("Attempt to cancel request for session (%d) for cid (%s) not in progress", crm.ses, crm.k.String())
+		return
+	}
+	listener, ok := requestStatus.listeners[crm.ses]
+	if !ok {
+		log.Errorf("Attempt to cancel request for session (%d) for cid (%s) this is not a listener", crm.ses, crm.k.String())
+		return
+	}
+	close(listener)
+	delete(requestStatus.listeners, crm.ses)
+}

--- a/providerquerymanager/providerquerymanager_test.go
+++ b/providerquerymanager/providerquerymanager_test.go
@@ -1,0 +1,274 @@
+package providerquerymanager
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-bitswap/testutil"
+
+	cid "github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-peer"
+)
+
+type fakeProviderNetwork struct {
+	peersFound   []peer.ID
+	connectError error
+	delay        time.Duration
+	connectDelay time.Duration
+	queriesMade  int
+}
+
+func (fpn *fakeProviderNetwork) ConnectTo(context.Context, peer.ID) error {
+	time.Sleep(fpn.connectDelay)
+	return fpn.connectError
+}
+
+func (fpn *fakeProviderNetwork) FindProvidersAsync(ctx context.Context, k cid.Cid, max int) <-chan peer.ID {
+	fpn.queriesMade++
+	incomingPeers := make(chan peer.ID)
+	go func() {
+		defer close(incomingPeers)
+		for _, p := range fpn.peersFound {
+			time.Sleep(fpn.delay)
+			select {
+			case incomingPeers <- p:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return incomingPeers
+}
+
+func TestNormalSimultaneousFetch(t *testing.T) {
+	peers := testutil.GeneratePeers(10)
+	fpn := &fakeProviderNetwork{
+		peersFound: peers,
+		delay:      1 * time.Millisecond,
+	}
+	ctx := context.Background()
+	providerQueryManager := New(ctx, fpn)
+	providerQueryManager.Startup()
+	keys := testutil.GenerateCids(2)
+	sessionID1 := testutil.GenerateSessionID()
+	sessionID2 := testutil.GenerateSessionID()
+
+	sessionCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[0], sessionID1)
+	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[1], sessionID2)
+
+	var firstPeersReceived []peer.ID
+	for p := range firstRequestChan {
+		firstPeersReceived = append(firstPeersReceived, p)
+	}
+
+	var secondPeersReceived []peer.ID
+	for p := range secondRequestChan {
+		secondPeersReceived = append(secondPeersReceived, p)
+	}
+
+	if len(firstPeersReceived) != len(peers) || len(secondPeersReceived) != len(peers) {
+		t.Fatal("Did not collect all peers for request that was completed")
+	}
+
+	if fpn.queriesMade != 2 {
+		t.Fatal("Did not dedup provider requests running simultaneously")
+	}
+}
+
+func TestDedupingProviderRequests(t *testing.T) {
+	peers := testutil.GeneratePeers(10)
+	fpn := &fakeProviderNetwork{
+		peersFound: peers,
+		delay:      1 * time.Millisecond,
+	}
+	ctx := context.Background()
+	providerQueryManager := New(ctx, fpn)
+	providerQueryManager.Startup()
+	key := testutil.GenerateCids(1)[0]
+	sessionID1 := testutil.GenerateSessionID()
+	sessionID2 := testutil.GenerateSessionID()
+
+	sessionCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	defer cancel()
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, sessionID1)
+	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, sessionID2)
+
+	var firstPeersReceived []peer.ID
+	for p := range firstRequestChan {
+		firstPeersReceived = append(firstPeersReceived, p)
+	}
+
+	var secondPeersReceived []peer.ID
+	for p := range secondRequestChan {
+		secondPeersReceived = append(secondPeersReceived, p)
+	}
+
+	if len(firstPeersReceived) != len(peers) || len(secondPeersReceived) != len(peers) {
+		t.Fatal("Did not collect all peers for request that was completed")
+	}
+
+	if !reflect.DeepEqual(firstPeersReceived, secondPeersReceived) {
+		t.Fatal("Did not receive the same response to both find provider requests")
+	}
+
+	if fpn.queriesMade != 1 {
+		t.Fatal("Did not dedup provider requests running simultaneously")
+	}
+}
+
+func TestCancelOneRequestDoesNotTerminateAnother(t *testing.T) {
+	peers := testutil.GeneratePeers(10)
+	fpn := &fakeProviderNetwork{
+		peersFound: peers,
+		delay:      1 * time.Millisecond,
+	}
+	ctx := context.Background()
+	providerQueryManager := New(ctx, fpn)
+	providerQueryManager.Startup()
+
+	key := testutil.GenerateCids(1)[0]
+	sessionID1 := testutil.GenerateSessionID()
+	sessionID2 := testutil.GenerateSessionID()
+
+	// first session will cancel before done
+	firstSessionCtx, firstCancel := context.WithTimeout(ctx, 3*time.Millisecond)
+	defer firstCancel()
+	firstRequestChan := providerQueryManager.FindProvidersAsync(firstSessionCtx, key, sessionID1)
+	secondSessionCtx, secondCancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	defer secondCancel()
+	secondRequestChan := providerQueryManager.FindProvidersAsync(secondSessionCtx, key, sessionID2)
+
+	var firstPeersReceived []peer.ID
+	for p := range firstRequestChan {
+		firstPeersReceived = append(firstPeersReceived, p)
+	}
+
+	var secondPeersReceived []peer.ID
+	for p := range secondRequestChan {
+		secondPeersReceived = append(secondPeersReceived, p)
+	}
+
+	if len(secondPeersReceived) != len(peers) {
+		t.Fatal("Did not collect all peers for request that was completed")
+	}
+
+	if len(firstPeersReceived) >= len(peers) {
+		t.Fatal("Collected all peers on cancelled peer, should have been cancelled immediately")
+	}
+
+	if fpn.queriesMade != 1 {
+		t.Fatal("Did not dedup provider requests running simultaneously")
+	}
+}
+
+func TestCancelManagerExitsGracefully(t *testing.T) {
+	peers := testutil.GeneratePeers(10)
+	fpn := &fakeProviderNetwork{
+		peersFound: peers,
+		delay:      1 * time.Millisecond,
+	}
+	ctx := context.Background()
+	managerCtx, managerCancel := context.WithTimeout(ctx, 5*time.Millisecond)
+	defer managerCancel()
+	providerQueryManager := New(managerCtx, fpn)
+	providerQueryManager.Startup()
+
+	key := testutil.GenerateCids(1)[0]
+	sessionID1 := testutil.GenerateSessionID()
+	sessionID2 := testutil.GenerateSessionID()
+
+	sessionCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	defer cancel()
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, sessionID1)
+	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, sessionID2)
+
+	var firstPeersReceived []peer.ID
+	for p := range firstRequestChan {
+		firstPeersReceived = append(firstPeersReceived, p)
+	}
+
+	var secondPeersReceived []peer.ID
+	for p := range secondRequestChan {
+		secondPeersReceived = append(secondPeersReceived, p)
+	}
+
+	if len(firstPeersReceived) <= 0 ||
+		len(firstPeersReceived) >= len(peers) ||
+		len(secondPeersReceived) <= 0 ||
+		len(secondPeersReceived) >= len(peers) {
+		t.Fatal("Did not cancel requests in progress correctly")
+	}
+}
+
+func TestPeersWithConnectionErrorsNotAddedToPeerList(t *testing.T) {
+	peers := testutil.GeneratePeers(10)
+	fpn := &fakeProviderNetwork{
+		peersFound:   peers,
+		connectError: errors.New("not able to connect"),
+		delay:        1 * time.Millisecond,
+	}
+	ctx := context.Background()
+	providerQueryManager := New(ctx, fpn)
+	providerQueryManager.Startup()
+
+	key := testutil.GenerateCids(1)[0]
+	sessionID1 := testutil.GenerateSessionID()
+	sessionID2 := testutil.GenerateSessionID()
+
+	sessionCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	defer cancel()
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, sessionID1)
+	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, sessionID2)
+
+	var firstPeersReceived []peer.ID
+	for p := range firstRequestChan {
+		firstPeersReceived = append(firstPeersReceived, p)
+	}
+
+	var secondPeersReceived []peer.ID
+	for p := range secondRequestChan {
+		secondPeersReceived = append(secondPeersReceived, p)
+	}
+
+	if len(firstPeersReceived) != 0 || len(secondPeersReceived) != 0 {
+		t.Fatal("Did not filter out peers with connection issues")
+	}
+
+}
+
+func TestRateLimitingRequests(t *testing.T) {
+	peers := testutil.GeneratePeers(10)
+	fpn := &fakeProviderNetwork{
+		peersFound: peers,
+		delay:      1 * time.Millisecond,
+	}
+	ctx := context.Background()
+	providerQueryManager := New(ctx, fpn)
+	providerQueryManager.Startup()
+
+	keys := testutil.GenerateCids(maxInProcessRequests + 1)
+	sessionID := testutil.GenerateSessionID()
+	sessionCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	defer cancel()
+	var requestChannels []<-chan peer.ID
+	for i := 0; i < maxInProcessRequests+1; i++ {
+		requestChannels = append(requestChannels, providerQueryManager.FindProvidersAsync(sessionCtx, keys[i], sessionID))
+	}
+	time.Sleep(2 * time.Millisecond)
+	if fpn.queriesMade != maxInProcessRequests {
+		t.Fatal("Did not limit parallel requests to rate limit")
+	}
+	for i := 0; i < maxInProcessRequests+1; i++ {
+		for range requestChannels[i] {
+		}
+	}
+
+	if fpn.queriesMade != maxInProcessRequests+1 {
+		t.Fatal("Did not make all seperate requests")
+	}
+}

--- a/providerquerymanager/providerquerymanager_test.go
+++ b/providerquerymanager/providerquerymanager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,11 +15,12 @@ import (
 )
 
 type fakeProviderNetwork struct {
-	peersFound   []peer.ID
-	connectError error
-	delay        time.Duration
-	connectDelay time.Duration
-	queriesMade  int
+	peersFound       []peer.ID
+	connectError     error
+	delay            time.Duration
+	connectDelay     time.Duration
+	queriesMadeMutex sync.RWMutex
+	queriesMade      int
 }
 
 func (fpn *fakeProviderNetwork) ConnectTo(context.Context, peer.ID) error {
@@ -27,12 +29,19 @@ func (fpn *fakeProviderNetwork) ConnectTo(context.Context, peer.ID) error {
 }
 
 func (fpn *fakeProviderNetwork) FindProvidersAsync(ctx context.Context, k cid.Cid, max int) <-chan peer.ID {
+	fpn.queriesMadeMutex.Lock()
 	fpn.queriesMade++
+	fpn.queriesMadeMutex.Unlock()
 	incomingPeers := make(chan peer.ID)
 	go func() {
 		defer close(incomingPeers)
 		for _, p := range fpn.peersFound {
 			time.Sleep(fpn.delay)
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 			select {
 			case incomingPeers <- p:
 			case <-ctx.Done():
@@ -75,9 +84,12 @@ func TestNormalSimultaneousFetch(t *testing.T) {
 		t.Fatal("Did not collect all peers for request that was completed")
 	}
 
+	fpn.queriesMadeMutex.Lock()
+	defer fpn.queriesMadeMutex.Unlock()
 	if fpn.queriesMade != 2 {
 		t.Fatal("Did not dedup provider requests running simultaneously")
 	}
+
 }
 
 func TestDedupingProviderRequests(t *testing.T) {
@@ -93,7 +105,7 @@ func TestDedupingProviderRequests(t *testing.T) {
 	sessionID1 := testutil.GenerateSessionID()
 	sessionID2 := testutil.GenerateSessionID()
 
-	sessionCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	sessionCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
 	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, sessionID1)
 	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, sessionID2)
@@ -115,7 +127,8 @@ func TestDedupingProviderRequests(t *testing.T) {
 	if !reflect.DeepEqual(firstPeersReceived, secondPeersReceived) {
 		t.Fatal("Did not receive the same response to both find provider requests")
 	}
-
+	fpn.queriesMadeMutex.Lock()
+	defer fpn.queriesMadeMutex.Unlock()
 	if fpn.queriesMade != 1 {
 		t.Fatal("Did not dedup provider requests running simultaneously")
 	}
@@ -139,7 +152,7 @@ func TestCancelOneRequestDoesNotTerminateAnother(t *testing.T) {
 	firstSessionCtx, firstCancel := context.WithTimeout(ctx, 3*time.Millisecond)
 	defer firstCancel()
 	firstRequestChan := providerQueryManager.FindProvidersAsync(firstSessionCtx, key, sessionID1)
-	secondSessionCtx, secondCancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	secondSessionCtx, secondCancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer secondCancel()
 	secondRequestChan := providerQueryManager.FindProvidersAsync(secondSessionCtx, key, sessionID2)
 
@@ -160,7 +173,8 @@ func TestCancelOneRequestDoesNotTerminateAnother(t *testing.T) {
 	if len(firstPeersReceived) >= len(peers) {
 		t.Fatal("Collected all peers on cancelled peer, should have been cancelled immediately")
 	}
-
+	fpn.queriesMadeMutex.Lock()
+	defer fpn.queriesMadeMutex.Unlock()
 	if fpn.queriesMade != 1 {
 		t.Fatal("Did not dedup provider requests running simultaneously")
 	}
@@ -248,26 +262,33 @@ func TestRateLimitingRequests(t *testing.T) {
 		delay:      1 * time.Millisecond,
 	}
 	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	providerQueryManager := New(ctx, fpn)
 	providerQueryManager.Startup()
 
 	keys := testutil.GenerateCids(maxInProcessRequests + 1)
 	sessionID := testutil.GenerateSessionID()
-	sessionCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	sessionCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
 	var requestChannels []<-chan peer.ID
 	for i := 0; i < maxInProcessRequests+1; i++ {
 		requestChannels = append(requestChannels, providerQueryManager.FindProvidersAsync(sessionCtx, keys[i], sessionID))
 	}
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(9 * time.Millisecond)
+	fpn.queriesMadeMutex.Lock()
 	if fpn.queriesMade != maxInProcessRequests {
+		t.Logf("Queries made: %d\n", fpn.queriesMade)
 		t.Fatal("Did not limit parallel requests to rate limit")
 	}
+	fpn.queriesMadeMutex.Unlock()
 	for i := 0; i < maxInProcessRequests+1; i++ {
 		for range requestChannels[i] {
 		}
 	}
 
+	fpn.queriesMadeMutex.Lock()
+	defer fpn.queriesMadeMutex.Unlock()
 	if fpn.queriesMade != maxInProcessRequests+1 {
 		t.Fatal("Did not make all seperate requests")
 	}
@@ -282,7 +303,7 @@ func TestFindProviderTimeout(t *testing.T) {
 	ctx := context.Background()
 	providerQueryManager := New(ctx, fpn)
 	providerQueryManager.Startup()
-	providerQueryManager.SetFindProviderTimeout(3 * time.Millisecond)
+	providerQueryManager.SetFindProviderTimeout(2 * time.Millisecond)
 	keys := testutil.GenerateCids(1)
 	sessionID1 := testutil.GenerateSessionID()
 
@@ -293,8 +314,7 @@ func TestFindProviderTimeout(t *testing.T) {
 	for p := range firstRequestChan {
 		firstPeersReceived = append(firstPeersReceived, p)
 	}
-	if len(firstPeersReceived) <= 0 ||
-		len(firstPeersReceived) >= len(peers) {
+	if len(firstPeersReceived) >= len(peers) {
 		t.Fatal("Find provider request should have timed out, did not")
 	}
 }

--- a/providerquerymanager/providerquerymanager_test.go
+++ b/providerquerymanager/providerquerymanager_test.go
@@ -211,9 +211,7 @@ func TestCancelManagerExitsGracefully(t *testing.T) {
 		secondPeersReceived = append(secondPeersReceived, p)
 	}
 
-	if len(firstPeersReceived) <= 0 ||
-		len(firstPeersReceived) >= len(peers) ||
-		len(secondPeersReceived) <= 0 ||
+	if len(firstPeersReceived) >= len(peers) ||
 		len(secondPeersReceived) >= len(peers) {
 		t.Fatal("Did not cancel requests in progress correctly")
 	}

--- a/providerquerymanager/providerquerymanager_test.go
+++ b/providerquerymanager/providerquerymanager_test.go
@@ -62,13 +62,11 @@ func TestNormalSimultaneousFetch(t *testing.T) {
 	providerQueryManager := New(ctx, fpn)
 	providerQueryManager.Startup()
 	keys := testutil.GenerateCids(2)
-	sessionID1 := testutil.GenerateSessionID()
-	sessionID2 := testutil.GenerateSessionID()
 
 	sessionCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
-	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[0], sessionID1)
-	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[1], sessionID2)
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[0])
+	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[1])
 
 	var firstPeersReceived []peer.ID
 	for p := range firstRequestChan {
@@ -102,13 +100,11 @@ func TestDedupingProviderRequests(t *testing.T) {
 	providerQueryManager := New(ctx, fpn)
 	providerQueryManager.Startup()
 	key := testutil.GenerateCids(1)[0]
-	sessionID1 := testutil.GenerateSessionID()
-	sessionID2 := testutil.GenerateSessionID()
 
 	sessionCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
-	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, sessionID1)
-	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, sessionID2)
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key)
+	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key)
 
 	var firstPeersReceived []peer.ID
 	for p := range firstRequestChan {
@@ -145,16 +141,14 @@ func TestCancelOneRequestDoesNotTerminateAnother(t *testing.T) {
 	providerQueryManager.Startup()
 
 	key := testutil.GenerateCids(1)[0]
-	sessionID1 := testutil.GenerateSessionID()
-	sessionID2 := testutil.GenerateSessionID()
 
 	// first session will cancel before done
 	firstSessionCtx, firstCancel := context.WithTimeout(ctx, 3*time.Millisecond)
 	defer firstCancel()
-	firstRequestChan := providerQueryManager.FindProvidersAsync(firstSessionCtx, key, sessionID1)
+	firstRequestChan := providerQueryManager.FindProvidersAsync(firstSessionCtx, key)
 	secondSessionCtx, secondCancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer secondCancel()
-	secondRequestChan := providerQueryManager.FindProvidersAsync(secondSessionCtx, key, sessionID2)
+	secondRequestChan := providerQueryManager.FindProvidersAsync(secondSessionCtx, key)
 
 	var firstPeersReceived []peer.ID
 	for p := range firstRequestChan {
@@ -193,13 +187,11 @@ func TestCancelManagerExitsGracefully(t *testing.T) {
 	providerQueryManager.Startup()
 
 	key := testutil.GenerateCids(1)[0]
-	sessionID1 := testutil.GenerateSessionID()
-	sessionID2 := testutil.GenerateSessionID()
 
 	sessionCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
 	defer cancel()
-	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, sessionID1)
-	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, sessionID2)
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key)
+	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key)
 
 	var firstPeersReceived []peer.ID
 	for p := range firstRequestChan {
@@ -229,13 +221,11 @@ func TestPeersWithConnectionErrorsNotAddedToPeerList(t *testing.T) {
 	providerQueryManager.Startup()
 
 	key := testutil.GenerateCids(1)[0]
-	sessionID1 := testutil.GenerateSessionID()
-	sessionID2 := testutil.GenerateSessionID()
 
 	sessionCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
 	defer cancel()
-	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, sessionID1)
-	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key, sessionID2)
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key)
+	secondRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, key)
 
 	var firstPeersReceived []peer.ID
 	for p := range firstRequestChan {
@@ -266,12 +256,11 @@ func TestRateLimitingRequests(t *testing.T) {
 	providerQueryManager.Startup()
 
 	keys := testutil.GenerateCids(maxInProcessRequests + 1)
-	sessionID := testutil.GenerateSessionID()
 	sessionCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
 	var requestChannels []<-chan peer.ID
 	for i := 0; i < maxInProcessRequests+1; i++ {
-		requestChannels = append(requestChannels, providerQueryManager.FindProvidersAsync(sessionCtx, keys[i], sessionID))
+		requestChannels = append(requestChannels, providerQueryManager.FindProvidersAsync(sessionCtx, keys[i]))
 	}
 	time.Sleep(9 * time.Millisecond)
 	fpn.queriesMadeMutex.Lock()
@@ -303,11 +292,10 @@ func TestFindProviderTimeout(t *testing.T) {
 	providerQueryManager.Startup()
 	providerQueryManager.SetFindProviderTimeout(2 * time.Millisecond)
 	keys := testutil.GenerateCids(1)
-	sessionID1 := testutil.GenerateSessionID()
 
 	sessionCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
-	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[0], sessionID1)
+	firstRequestChan := providerQueryManager.FindProvidersAsync(sessionCtx, keys[0])
 	var firstPeersReceived []peer.ID
 	for p := range firstRequestChan {
 		firstPeersReceived = append(firstPeersReceived, p)

--- a/sessionpeermanager/sessionpeermanager.go
+++ b/sessionpeermanager/sessionpeermanager.go
@@ -26,7 +26,7 @@ type PeerTagger interface {
 
 // PeerProviderFinder is an interface for finding providers
 type PeerProviderFinder interface {
-	FindProvidersAsync(context.Context, cid.Cid, uint64) <-chan peer.ID
+	FindProvidersAsync(context.Context, cid.Cid) <-chan peer.ID
 }
 
 type peerMessage interface {
@@ -108,8 +108,8 @@ func (spm *SessionPeerManager) GetOptimizedPeers() []peer.ID {
 // providers for the given Cid
 func (spm *SessionPeerManager) FindMorePeers(ctx context.Context, c cid.Cid) {
 	go func(k cid.Cid) {
-		for p := range spm.providerFinder.FindProvidersAsync(ctx, k, spm.id) {
-			
+		for p := range spm.providerFinder.FindProvidersAsync(ctx, k) {
+
 			select {
 			case spm.peerMessages <- &peerFoundMessage{p}:
 			case <-ctx.Done():

--- a/sessionpeermanager/sessionpeermanager_test.go
+++ b/sessionpeermanager/sessionpeermanager_test.go
@@ -18,7 +18,7 @@ type fakePeerProviderFinder struct {
 	completed chan struct{}
 }
 
-func (fppf *fakePeerProviderFinder) FindProvidersAsync(ctx context.Context, c cid.Cid, ses uint64) <-chan peer.ID {
+func (fppf *fakePeerProviderFinder) FindProvidersAsync(ctx context.Context, c cid.Cid) <-chan peer.ID {
 	peerCh := make(chan peer.ID)
 	go func() {
 


### PR DESCRIPTION
# Goals

Build a robust provider finder for sessions so that we can deduplicate provider logic (#52) and soon merge GetBlock w/ Session.GetBlocks (#49)

# Implementation

A manager for find provider requests that:
- dedups requests
- rate limits requests
- manages timeouts
- handles connecting to peers once they are found

# For discussion

Will writeup general concurrency architecture tomorrow