### PR TITLE
fix(wantlist): remove races on setup

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -132,7 +132,6 @@ func New(parent context.Context, network bsnet.BitSwapNetwork,
 	}
 
 	bs.wm.SetDelegate(bs.pm)
-	bs.pm.Startup()
 	bs.wm.Startup()
 	bs.pqm.Startup()
 	network.SetDelegate(bs)
@@ -361,14 +360,13 @@ func (bs *Bitswap) updateReceiveCounters(b blocks.Block) {
 
 // Connected/Disconnected warns bitswap about peer connections.
 func (bs *Bitswap) PeerConnected(p peer.ID) {
-	initialWants := bs.wm.CurrentBroadcastWants()
-	bs.pm.Connected(p, initialWants)
+	bs.wm.Connected(p)
 	bs.engine.PeerConnected(p)
 }
 
 // Connected/Disconnected warns bitswap about peer connections.
 func (bs *Bitswap) PeerDisconnected(p peer.ID) {
-	bs.pm.Disconnected(p)
+	bs.wm.Disconnected(p)
 	bs.engine.PeerDisconnected(p)
 }
 

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -34,8 +34,6 @@ type MessageQueue struct {
 
 	sender bsnet.MessageSender
 
-	refcnt int
-
 	work chan struct{}
 	done chan struct{}
 }
@@ -48,25 +46,7 @@ func New(p peer.ID, network MessageNetwork) *MessageQueue {
 		wl:      wantlist.NewThreadSafe(),
 		network: network,
 		p:       p,
-		refcnt:  0,
 	}
-}
-
-// RefCount returns the number of open connections for this queue.
-func (mq *MessageQueue) RefCount() int {
-	return mq.refcnt
-}
-
-// RefIncrement increments the refcount for a message queue.
-func (mq *MessageQueue) RefIncrement() {
-	mq.refcnt++
-}
-
-// RefDecrement decrements the refcount for a message queue and returns true
-// if the refcount is now 0.
-func (mq *MessageQueue) RefDecrement() bool {
-	mq.refcnt--
-	return mq.refcnt > 0
 }
 
 // AddMessage adds new entries to an outgoing message for a given session.

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -14,6 +14,8 @@ import (
 
 var log = logging.Logger("bitswap")
 
+const maxRetries = 10
+
 // MessageNetwork is any network that can connect peers and generate a message
 // sender.
 type MessageNetwork interface {
@@ -162,7 +164,7 @@ func (mq *MessageQueue) doWork(ctx context.Context) {
 	}
 
 	// send wantlist updates
-	for { // try to send this message until we fail.
+	for i := 0; i < maxRetries; i++ { // try to send this message until we fail.
 		if mq.attemptSendAndRecovery(ctx, wlm) {
 			return
 		}

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -48,7 +48,7 @@ func New(p peer.ID, network MessageNetwork) *MessageQueue {
 		wl:      wantlist.NewThreadSafe(),
 		network: network,
 		p:       p,
-		refcnt:  1,
+		refcnt:  0,
 	}
 }
 

--- a/messagequeue/messagequeue_test.go
+++ b/messagequeue/messagequeue_test.go
@@ -81,8 +81,8 @@ func TestStartupAndShutdown(t *testing.T) {
 	ses := testutil.GenerateSessionID()
 	wl := testutil.GenerateWantlist(10, ses)
 
-	messageQueue.Startup(ctx, wl.Entries(), nil, 0)
-
+	messageQueue.Startup(ctx)
+	messageQueue.AddWantlist(wl.Entries())
 	messages := collectMessages(ctx, t, messagesSent, 10*time.Millisecond)
 	if len(messages) != 1 {
 		t.Fatal("wrong number of messages were sent for initial wants")
@@ -123,8 +123,9 @@ func TestSendingMessagesDeduped(t *testing.T) {
 	ses1 := testutil.GenerateSessionID()
 	ses2 := testutil.GenerateSessionID()
 	entries := testutil.GenerateMessageEntries(10, false)
-	messageQueue.Startup(ctx, nil, entries, ses1)
+	messageQueue.Startup(ctx)
 
+	messageQueue.AddMessage(entries, ses1)
 	messageQueue.AddMessage(entries, ses2)
 	messages := collectMessages(ctx, t, messagesSent, 10*time.Millisecond)
 
@@ -147,8 +148,9 @@ func TestSendingMessagesPartialDupe(t *testing.T) {
 	entries := testutil.GenerateMessageEntries(10, false)
 	moreEntries := testutil.GenerateMessageEntries(5, false)
 	secondEntries := append(entries[5:], moreEntries...)
-	messageQueue.Startup(ctx, nil, entries, ses1)
+	messageQueue.Startup(ctx)
 
+	messageQueue.AddMessage(entries, ses1)
 	messageQueue.AddMessage(secondEntries, ses2)
 	messages := collectMessages(ctx, t, messagesSent, 20*time.Millisecond)
 

--- a/messagequeue/messagequeue_test.go
+++ b/messagequeue/messagequeue_test.go
@@ -25,9 +25,9 @@ func (fmn *fakeMessageNetwork) ConnectTo(context.Context, peer.ID) error {
 func (fmn *fakeMessageNetwork) NewMessageSender(context.Context, peer.ID) (bsnet.MessageSender, error) {
 	if fmn.messageSenderError == nil {
 		return fmn.messageSender, nil
-	} else {
-		return nil, fmn.messageSenderError
 	}
+	return nil, fmn.messageSenderError
+
 }
 
 type fakeMessageSender struct {
@@ -81,7 +81,7 @@ func TestStartupAndShutdown(t *testing.T) {
 	ses := testutil.GenerateSessionID()
 	wl := testutil.GenerateWantlist(10, ses)
 
-	messageQueue.Startup(ctx, wl.Entries())
+	messageQueue.Startup(ctx, wl.Entries(), nil, 0)
 
 	messages := collectMessages(ctx, t, messagesSent, 10*time.Millisecond)
 	if len(messages) != 1 {
@@ -123,9 +123,8 @@ func TestSendingMessagesDeduped(t *testing.T) {
 	ses1 := testutil.GenerateSessionID()
 	ses2 := testutil.GenerateSessionID()
 	entries := testutil.GenerateMessageEntries(10, false)
-	messageQueue.Startup(ctx, nil)
+	messageQueue.Startup(ctx, nil, entries, ses1)
 
-	messageQueue.AddMessage(entries, ses1)
 	messageQueue.AddMessage(entries, ses2)
 	messages := collectMessages(ctx, t, messagesSent, 10*time.Millisecond)
 
@@ -148,9 +147,8 @@ func TestSendingMessagesPartialDupe(t *testing.T) {
 	entries := testutil.GenerateMessageEntries(10, false)
 	moreEntries := testutil.GenerateMessageEntries(5, false)
 	secondEntries := append(entries[5:], moreEntries...)
-	messageQueue.Startup(ctx, nil)
+	messageQueue.Startup(ctx, nil, entries, ses1)
 
-	messageQueue.AddMessage(entries, ses1)
 	messageQueue.AddMessage(secondEntries, ses2)
 	messages := collectMessages(ctx, t, messagesSent, 20*time.Millisecond)
 

--- a/peermanager/peermanager.go
+++ b/peermanager/peermanager.go
@@ -2,6 +2,7 @@ package peermanager
 
 import (
 	"context"
+	"sync"
 
 	bsmsg "github.com/ipfs/go-bitswap/message"
 	wantlist "github.com/ipfs/go-bitswap/wantlist"
@@ -34,150 +35,56 @@ type peerMessage interface {
 
 // PeerManager manages a pool of peers and sends messages to peers in the pool.
 type PeerManager struct {
-	// sync channel for Run loop
-	peerMessages chan peerMessage
-
-	// synchronized by Run loop, only touch inside there
-	peerQueues map[peer.ID]PeerQueue
-
+	peerQueues      map[peer.ID]PeerQueue
+	lk              sync.RWMutex
 	createPeerQueue PeerQueueFactory
 	ctx             context.Context
-	cancel          func()
 }
 
 // New creates a new PeerManager, given a context and a peerQueueFactory.
 func New(ctx context.Context, createPeerQueue PeerQueueFactory) *PeerManager {
-	ctx, cancel := context.WithCancel(ctx)
 	return &PeerManager{
-		peerMessages:    make(chan peerMessage, 10),
 		peerQueues:      make(map[peer.ID]PeerQueue),
 		createPeerQueue: createPeerQueue,
 		ctx:             ctx,
-		cancel:          cancel,
 	}
 }
 
 // ConnectedPeers returns a list of peers this PeerManager is managing.
 func (pm *PeerManager) ConnectedPeers() []peer.ID {
-	resp := make(chan []peer.ID, 1)
-	select {
-	case pm.peerMessages <- &getPeersMessage{resp}:
-	case <-pm.ctx.Done():
-		return nil
+	pm.lk.RLock()
+	defer pm.lk.RUnlock()
+
+	peers := make([]peer.ID, 0, len(pm.peerQueues))
+	for p := range pm.peerQueues {
+		peers = append(peers, p)
 	}
-	select {
-	case peers := <-resp:
-		return peers
-	case <-pm.ctx.Done():
-		return nil
-	}
+
+	return peers
 }
 
 // Connected is called to add a new peer to the pool, and send it an initial set
 // of wants.
 func (pm *PeerManager) Connected(p peer.ID, initialEntries []*wantlist.Entry) {
-	select {
-	case pm.peerMessages <- &connectPeerMessage{p, initialEntries}:
-	case <-pm.ctx.Done():
-	}
-}
+	pm.lk.Lock()
+	defer pm.lk.Unlock()
 
-// Disconnected is called to remove a peer from the pool.
-func (pm *PeerManager) Disconnected(p peer.ID) {
-	select {
-	case pm.peerMessages <- &disconnectPeerMessage{p}:
-	case <-pm.ctx.Done():
-	}
-}
-
-// SendMessage is called to send a message to all or some peers in the pool;
-// if targets is nil, it sends to all.
-func (pm *PeerManager) SendMessage(entries []*bsmsg.Entry, targets []peer.ID, from uint64) {
-	select {
-	case pm.peerMessages <- &sendPeerMessage{entries: entries, targets: targets, from: from}:
-	case <-pm.ctx.Done():
-	}
-}
-
-// Startup enables the run loop for the PeerManager - no processing will occur
-// if startup is not called.
-func (pm *PeerManager) Startup() {
-	go pm.run()
-}
-
-// Shutdown shutsdown processing for the PeerManager.
-func (pm *PeerManager) Shutdown() {
-	pm.cancel()
-}
-
-func (pm *PeerManager) run() {
-	for {
-		select {
-		case message := <-pm.peerMessages:
-			message.handle(pm)
-		case <-pm.ctx.Done():
-			return
-		}
-	}
-}
-
-type sendPeerMessage struct {
-	entries []*bsmsg.Entry
-	targets []peer.ID
-	from    uint64
-}
-
-func (s *sendPeerMessage) handle(pm *PeerManager) {
-	pm.sendMessage(s)
-}
-
-type connectPeerMessage struct {
-	p              peer.ID
-	initialEntries []*wantlist.Entry
-}
-
-func (c *connectPeerMessage) handle(pm *PeerManager) {
-	pm.startPeerHandler(c.p, c.initialEntries)
-}
-
-type disconnectPeerMessage struct {
-	p peer.ID
-}
-
-func (dc *disconnectPeerMessage) handle(pm *PeerManager) {
-	pm.stopPeerHandler(dc.p)
-}
-
-type getPeersMessage struct {
-	peerResp chan<- []peer.ID
-}
-
-func (gp *getPeersMessage) handle(pm *PeerManager) {
-	pm.getPeers(gp.peerResp)
-}
-
-func (pm *PeerManager) getPeers(peerResp chan<- []peer.ID) {
-	peers := make([]peer.ID, 0, len(pm.peerQueues))
-	for p := range pm.peerQueues {
-		peers = append(peers, p)
-	}
-	peerResp <- peers
-}
-
-func (pm *PeerManager) startPeerHandler(p peer.ID, initialEntries []*wantlist.Entry) PeerQueue {
 	mq, ok := pm.peerQueues[p]
 	if ok {
 		mq.RefIncrement()
-		return nil
+		return
 	}
 
 	mq = pm.createPeerQueue(p)
 	pm.peerQueues[p] = mq
 	mq.Startup(pm.ctx, initialEntries)
-	return mq
 }
 
-func (pm *PeerManager) stopPeerHandler(p peer.ID) {
+// Disconnected is called to remove a peer from the pool.
+func (pm *PeerManager) Disconnected(p peer.ID) {
+	pm.lk.Lock()
+	defer pm.lk.Unlock()
+
 	pq, ok := pm.peerQueues[p]
 	if !ok {
 		// TODO: log error?
@@ -192,19 +99,28 @@ func (pm *PeerManager) stopPeerHandler(p peer.ID) {
 	delete(pm.peerQueues, p)
 }
 
-func (pm *PeerManager) sendMessage(ms *sendPeerMessage) {
-	if len(ms.targets) == 0 {
+// SendMessage is called to send a message to all or some peers in the pool;
+// if targets is nil, it sends to all.
+func (pm *PeerManager) SendMessage(initialEntries []*wantlist.Entry, entries []*bsmsg.Entry, targets []peer.ID, from uint64) {
+	pm.lk.Lock()
+	defer pm.lk.Unlock()
+
+	if len(targets) == 0 {
 		for _, p := range pm.peerQueues {
-			p.AddMessage(ms.entries, ms.from)
+			p.AddMessage(entries, from)
 		}
 	} else {
-		for _, t := range ms.targets {
+		for _, t := range targets {
 			p, ok := pm.peerQueues[t]
 			if !ok {
-				log.Infof("tried sending wantlist change to non-partner peer: %s", t)
-				continue
+				p = pm.createPeerQueue(t)
+				pm.peerQueues[t] = p
+				p.Startup(pm.ctx, initialEntries)
+				// this is a "0 reference" queue because we haven't actually connected to it
+				// sending the first message will cause it to connect
+				p.RefDecrement()
 			}
-			p.AddMessage(ms.entries, ms.from)
+			p.AddMessage(entries, from)
 		}
 	}
 }

--- a/peermanager/peermanager.go
+++ b/peermanager/peermanager.go
@@ -37,8 +37,10 @@ type peerMessage interface {
 
 // PeerManager manages a pool of peers and sends messages to peers in the pool.
 type PeerManager struct {
-	peerQueues      map[peer.ID]PeerQueue
-	lk              sync.RWMutex
+	// peerQueues -- interact through internal utility functions get/set/remove/iterate
+	peerQueues   map[peer.ID]PeerQueue
+	peerQueuesLk sync.RWMutex
+
 	createPeerQueue PeerQueueFactory
 	ctx             context.Context
 }
@@ -54,24 +56,19 @@ func New(ctx context.Context, createPeerQueue PeerQueueFactory) *PeerManager {
 
 // ConnectedPeers returns a list of peers this PeerManager is managing.
 func (pm *PeerManager) ConnectedPeers() []peer.ID {
-	pm.lk.RLock()
-	defer pm.lk.RUnlock()
 
 	peers := make([]peer.ID, 0, len(pm.peerQueues))
-	for p := range pm.peerQueues {
+	pm.iterate(func(p peer.ID, _ PeerQueue) {
 		peers = append(peers, p)
-	}
-
+	})
 	return peers
 }
 
 // Connected is called to add a new peer to the pool, and send it an initial set
 // of wants.
 func (pm *PeerManager) Connected(p peer.ID, initialEntries []*wantlist.Entry) {
-	pm.lk.Lock()
-	defer pm.lk.Unlock()
+	mq, ok := pm.get(p)
 
-	mq, ok := pm.peerQueues[p]
 	if ok {
 		if mq.RefCount() == 0 {
 			mq.AddWantlist(initialEntries)
@@ -81,17 +78,17 @@ func (pm *PeerManager) Connected(p peer.ID, initialEntries []*wantlist.Entry) {
 	}
 
 	mq = pm.createPeerQueue(p)
-	pm.peerQueues[p] = mq
+
+	pm.set(p, mq)
+
 	mq.Startup(pm.ctx)
 	mq.AddWantlist(initialEntries)
 }
 
 // Disconnected is called to remove a peer from the pool.
 func (pm *PeerManager) Disconnected(p peer.ID) {
-	pm.lk.Lock()
-	defer pm.lk.Unlock()
+	pq, ok := pm.get(p)
 
-	pq, ok := pm.peerQueues[p]
 	if !ok {
 		// TODO: log error?
 		return
@@ -102,25 +99,23 @@ func (pm *PeerManager) Disconnected(p peer.ID) {
 	}
 
 	pq.Shutdown()
-	delete(pm.peerQueues, p)
+
+	pm.remove(p)
 }
 
 // SendMessage is called to send a message to all or some peers in the pool;
 // if targets is nil, it sends to all.
 func (pm *PeerManager) SendMessage(entries []*bsmsg.Entry, targets []peer.ID, from uint64) {
-	pm.lk.Lock()
-	defer pm.lk.Unlock()
-
 	if len(targets) == 0 {
-		for _, p := range pm.peerQueues {
+		pm.iterate(func(_ peer.ID, p PeerQueue) {
 			p.AddMessage(entries, from)
-		}
+		})
 	} else {
 		for _, t := range targets {
-			p, ok := pm.peerQueues[t]
+			p, ok := pm.get(t)
 			if !ok {
 				p = pm.createPeerQueue(t)
-				pm.peerQueues[t] = p
+				pm.set(t, p)
 				p.Startup(pm.ctx)
 				// this is a "0 reference" queue because we haven't actually connected to it
 				// sending the first message will cause it to connect
@@ -129,4 +124,31 @@ func (pm *PeerManager) SendMessage(entries []*bsmsg.Entry, targets []peer.ID, fr
 			p.AddMessage(entries, from)
 		}
 	}
+}
+
+func (pm *PeerManager) get(p peer.ID) (PeerQueue, bool) {
+	pm.peerQueuesLk.RLock()
+	pq, ok := pm.peerQueues[p]
+	pm.peerQueuesLk.RUnlock()
+	return pq, ok
+}
+
+func (pm *PeerManager) set(p peer.ID, pq PeerQueue) {
+	pm.peerQueuesLk.Lock()
+	pm.peerQueues[p] = pq
+	pm.peerQueuesLk.Unlock()
+}
+
+func (pm *PeerManager) remove(p peer.ID) {
+	pm.peerQueuesLk.Lock()
+	delete(pm.peerQueues, p)
+	pm.peerQueuesLk.Unlock()
+}
+
+func (pm *PeerManager) iterate(iterateFn func(peer.ID, PeerQueue)) {
+	pm.peerQueuesLk.RLock()
+	for p, pq := range pm.peerQueues {
+		iterateFn(p, pq)
+	}
+	pm.peerQueuesLk.RUnlock()
 }

--- a/peermanager/peermanager_test.go
+++ b/peermanager/peermanager_test.go
@@ -41,7 +41,7 @@ func makePeerQueueFactory(messagesSent chan messageSent) PeerQueueFactory {
 	return func(p peer.ID) PeerQueue {
 		return &fakePeer{
 			p:            p,
-			refcnt:       1,
+			refcnt:       0,
 			messagesSent: messagesSent,
 		}
 	}

--- a/peermanager/peermanager_test.go
+++ b/peermanager/peermanager_test.go
@@ -20,19 +20,13 @@ type messageSent struct {
 }
 
 type fakePeer struct {
-	refcnt       int
 	p            peer.ID
 	messagesSent chan messageSent
 }
 
 func (fp *fakePeer) Startup(ctx context.Context) {}
 func (fp *fakePeer) Shutdown()                   {}
-func (fp *fakePeer) RefCount() int               { return fp.refcnt }
-func (fp *fakePeer) RefIncrement()               { fp.refcnt++ }
-func (fp *fakePeer) RefDecrement() bool {
-	fp.refcnt--
-	return fp.refcnt > 0
-}
+
 func (fp *fakePeer) AddMessage(entries []*bsmsg.Entry, ses uint64) {
 	fp.messagesSent <- messageSent{fp.p, entries, ses}
 }
@@ -41,7 +35,6 @@ func makePeerQueueFactory(messagesSent chan messageSent) PeerQueueFactory {
 	return func(p peer.ID) PeerQueue {
 		return &fakePeer{
 			p:            p,
-			refcnt:       0,
 			messagesSent: messagesSent,
 		}
 	}

--- a/peermanager/peermanager_test.go
+++ b/peermanager/peermanager_test.go
@@ -25,9 +25,13 @@ type fakePeer struct {
 	messagesSent chan messageSent
 }
 
-func (fp *fakePeer) Startup(ctx context.Context, initialEntries []*wantlist.Entry) {}
-func (fp *fakePeer) Shutdown()                                                     {}
-func (fp *fakePeer) RefIncrement()                                                 { fp.refcnt++ }
+func (fp *fakePeer) Startup(ctx context.Context, initialEntries []*wantlist.Entry, entries []*bsmsg.Entry, ses uint64) {
+	if entries != nil {
+		fp.AddMessage(entries, ses)
+	}
+}
+func (fp *fakePeer) Shutdown()     {}
+func (fp *fakePeer) RefIncrement() { fp.refcnt++ }
 func (fp *fakePeer) RefDecrement() bool {
 	fp.refcnt--
 	return fp.refcnt > 0

--- a/wantmanager/wantmanager.go
+++ b/wantmanager/wantmanager.go
@@ -25,7 +25,7 @@ const (
 type PeerHandler interface {
 	Disconnected(p peer.ID)
 	Connected(p peer.ID, initialEntries []*wantlist.Entry)
-	SendMessage(initialEntries []*wantlist.Entry, entries []*bsmsg.Entry, targets []peer.ID, from uint64)
+	SendMessage(entries []*bsmsg.Entry, targets []peer.ID, from uint64)
 }
 
 type wantMessage interface {
@@ -232,7 +232,7 @@ func (ws *wantSet) handle(wm *WantManager) {
 	}
 
 	// broadcast those wantlist changes
-	wm.peerHandler.SendMessage(wm.bcwl.Entries(), ws.entries, ws.targets, ws.from)
+	wm.peerHandler.SendMessage(ws.entries, ws.targets, ws.from)
 }
 
 type isWantedMessage struct {

--- a/wantmanager/wantmanager_test.go
+++ b/wantmanager/wantmanager_test.go
@@ -15,15 +15,13 @@ import (
 )
 
 type fakePeerHandler struct {
-	lk             sync.RWMutex
-	lastWantSet    wantSet
-	initialEntries []*wantlist.Entry
+	lk          sync.RWMutex
+	lastWantSet wantSet
 }
 
-func (fph *fakePeerHandler) SendMessage(initialEntries []*wantlist.Entry, entries []*bsmsg.Entry, targets []peer.ID, from uint64) {
+func (fph *fakePeerHandler) SendMessage(entries []*bsmsg.Entry, targets []peer.ID, from uint64) {
 	fph.lk.Lock()
 	fph.lastWantSet = wantSet{entries, targets, from}
-	fph.initialEntries = initialEntries
 	fph.lk.Unlock()
 }
 


### PR DESCRIPTION
# Goals

fix race conditions while setting up wantlists 

# Implementation

This change essentially solves bugs in initial wantlist handling using the strategy outlined by @Stebalien in #51. 

This means two differences:
- Have WantManager handle connect/disconnects and forward to the peer manager
- In the case the peer manager accidentally receives a request to send a message to a peer it's not connected to, create a "temporary peer" queue on demand, which will automatically initiate the connection when it opens a message stream to send a message
- This means to send a message we need the broadcast want list just in case

Other notable changes:
- Remove the go routine from the PeerManager, since basically all it's doing is managing a map
- Add a retry limit to peer message queues, cause we might be connecting to less reliable peers
- Add sending initial changes on startup for a peer message queue if present, so that our initial message contains them

# For Discussion

fix #51 fix #48 