### PR TITLE
fix multiple data races

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	bssrs "github.com/ipfs/go-bitswap/sessionrequestsplitter"
@@ -292,7 +291,9 @@ func (bs *Bitswap) receiveBlockFrom(blk blocks.Block, from peer.ID) error {
 }
 
 func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg.BitSwapMessage) {
-	atomic.AddUint64(&bs.counters.messagesRecvd, 1)
+	bs.counterLk.Lock()
+	bs.counters.messagesRecvd++
+	bs.counterLk.Unlock()
 
 	// This call records changes to wantlists, blocks received,
 	// and number of bytes transfered.

--- a/bitswap_test.go
+++ b/bitswap_test.go
@@ -140,7 +140,7 @@ func TestLargeSwarm(t *testing.T) {
 	if detectrace.WithRace() {
 		// when running with the race detector, 500 instances launches
 		// well over 8k goroutines. This hits a race detector limit.
-		numInstances = 75
+		numInstances = 50
 	} else if travis.IsRunning() {
 		numInstances = 200
 	} else {

--- a/bitswap_with_sessions_test.go
+++ b/bitswap_with_sessions_test.go
@@ -104,7 +104,11 @@ func TestSessionBetweenPeers(t *testing.T) {
 		}
 	}
 	for _, is := range inst[2:] {
-		if is.Exchange.counters.messagesRecvd > 2 {
+		stat, err := is.Exchange.Stat()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if stat.MessagesReceived > 2 {
 			t.Fatal("uninvolved nodes should only receive two messages", is.Exchange.counters.messagesRecvd)
 		}
 	}

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -114,7 +114,7 @@ func TestShutdownBeforeUnsubscribe(t *testing.T) {
 		if ok {
 			t.Fatal("channel should have been closed")
 		}
-	default:
+	case <-time.After(5 * time.Second):
 		t.Fatal("channel should have been closed")
 	}
 }


### PR DESCRIPTION
* fix pubsub race: Calling `wg.Add` after `wg.Wait` has returned is invalid. This change swaps the wait group for a plain rwmutex.
* fix Stat race: mixing atomics with locks doesn't work.
* fix race detector.

(caught with the race detector)