### PR TITLE
Reduce memory allocation

### DIFF
--- a/network/ipfs_impl.go
+++ b/network/ipfs_impl.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -74,30 +73,24 @@ func msgToStream(ctx context.Context, s inet.Stream, msg bsmsg.BitSwapMessage) e
 	if dl, ok := ctx.Deadline(); ok {
 		deadline = dl
 	}
+
 	if err := s.SetWriteDeadline(deadline); err != nil {
 		log.Warningf("error setting deadline: %s", err)
 	}
 
-	w := bufio.NewWriter(s)
-
 	switch s.Protocol() {
 	case ProtocolBitswap:
-		if err := msg.ToNetV1(w); err != nil {
+		if err := msg.ToNetV1(s); err != nil {
 			log.Debugf("error: %s", err)
 			return err
 		}
 	case ProtocolBitswapOne, ProtocolBitswapNoVers:
-		if err := msg.ToNetV0(w); err != nil {
+		if err := msg.ToNetV0(s); err != nil {
 			log.Debugf("error: %s", err)
 			return err
 		}
 	default:
 		return fmt.Errorf("unrecognized protocol on remote: %s", s.Protocol())
-	}
-
-	if err := w.Flush(); err != nil {
-		log.Debugf("error: %s", err)
-		return err
 	}
 
 	if err := s.SetWriteDeadline(time.Time{}); err != nil {


### PR DESCRIPTION
This reverts commit fc1278e68095a1d8f367ea4b37a571a0a137d65c.

It appears that using a buffer here is no longer necessary after the
upstream fix https://github.com/gogo/protobuf/pull/504

The `bufio.NewWriter` looks to be responsible for nearly half the allocations (by size) on a heavily loaded ipfs daemon:

```
(pprof) peek msgToStream
Showing nodes accounting for 193647.89MB, 100% of 193647.89MB total
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context 	 	 
----------------------------------------------------------+-------------
                                        92608.33MB   100% |   gx/ipfs/QmcSPuzpSbVLU6UHU4e5PwZpm4fHbCn5SbNR5ZNL6Mj63G/go-bitswap/network.(*streamMessageSender).SendMsg
                                            7.47MB 0.0081% |   gx/ipfs/QmcSPuzpSbVLU6UHU4e5PwZpm4fHbCn5SbNR5ZNL6Mj63G/go-bitswap/network.(*impl).SendMessage
         0     0%     0% 92615.80MB 47.83%                | gx/ipfs/QmcSPuzpSbVLU6UHU4e5PwZpm4fHbCn5SbNR5ZNL6Mj63G/go-bitswap/network.msgToStream
                                        80303.55MB 86.71% |   bufio.NewWriter
                                         8285.02MB  8.95% |   gx/ipfs/QmcSPuzpSbVLU6UHU4e5PwZpm4fHbCn5SbNR5ZNL6Mj63G/go-bitswap/message.(*impl).ToNetV1
                                         2802.69MB  3.03% |   bufio.(*Writer).Flush
                                         1216.04MB  1.31% |   gx/ipfs/Qma3Xp3FXFSP4prirEiRYHJ2tgGE8EAx9i6JLziPLpAQjq/go-libp2p-swarm.(*Stream).SetWriteDeadline
                                            8.50MB 0.0092% |   gx/ipfs/QmcSPuzpSbVLU6UHU4e5PwZpm4fHbCn5SbNR5ZNL6Mj63G/go-bitswap/message.(*impl).ToNetV0
```