### PR TITLE
Serialize receipt peer ID using base58 encoding

### DIFF
--- a/decision/engine.go
+++ b/decision/engine.go
@@ -121,7 +121,7 @@ func (e *Engine) LedgerForPeer(p peer.ID) *Receipt {
 	defer ledger.lk.Unlock()
 
 	return &Receipt{
-		Peer:      ledger.Partner.String(),
+		Peer:      ledger.Partner.Pretty(),
 		Value:     ledger.Accounting.Value(),
 		Sent:      ledger.Accounting.BytesSent,
 		Recv:      ledger.Accounting.BytesRecv,


### PR DESCRIPTION
Currently, `Receipt.Peer` contains a peer ID serialized using the `String()` method. Base58 encoding should probably be used instead.

Fixes https://github.com/ipfs/go-ipfs/issues/6020