### PR TITLE
feat(messagequeue): rebroadcast wantlist

### DIFF
--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -79,7 +79,9 @@ func (mq *MessageQueue) AddWantlist(initialWants *wantlist.SessionTrackedWantlis
 func (mq *MessageQueue) SetRebroadcastInterval(delay time.Duration) {
 	mq.rebroadcastIntervalLk.Lock()
 	mq.rebroadcastInterval = delay
-	mq.rebroadcastTimer.Reset(delay)
+	if mq.rebroadcastTimer != nil {
+		mq.rebroadcastTimer.Reset(delay)
+	}
 	mq.rebroadcastIntervalLk.Unlock()
 }
 

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -14,7 +14,10 @@ import (
 
 var log = logging.Logger("bitswap")
 
-const maxRetries = 10
+const (
+	defaultRebroadcastInterval = 30 * time.Second
+	maxRetries                 = 10
+)
 
 // MessageNetwork is any network that can connect peers and generate a message
 // sender.
@@ -33,21 +36,25 @@ type MessageQueue struct {
 	done         chan struct{}
 
 	// do not touch out of run loop
-	wl            *wantlist.SessionTrackedWantlist
-	nextMessage   bsmsg.BitSwapMessage
-	nextMessageLk sync.RWMutex
-	sender        bsnet.MessageSender
+	wl                    *wantlist.SessionTrackedWantlist
+	nextMessage           bsmsg.BitSwapMessage
+	nextMessageLk         sync.RWMutex
+	sender                bsnet.MessageSender
+	rebroadcastIntervalLk sync.RWMutex
+	rebroadcastInterval   time.Duration
+	rebroadcastTimer      *time.Timer
 }
 
 // New creats a new MessageQueue.
 func New(ctx context.Context, p peer.ID, network MessageNetwork) *MessageQueue {
 	return &MessageQueue{
-		ctx:          ctx,
-		wl:           wantlist.NewSessionTrackedWantlist(),
-		network:      network,
-		p:            p,
-		outgoingWork: make(chan struct{}, 1),
-		done:         make(chan struct{}),
+		ctx:                 ctx,
+		wl:                  wantlist.NewSessionTrackedWantlist(),
+		network:             network,
+		p:                   p,
+		outgoingWork:        make(chan struct{}, 1),
+		done:                make(chan struct{}),
+		rebroadcastInterval: defaultRebroadcastInterval,
 	}
 }
 
@@ -64,27 +71,24 @@ func (mq *MessageQueue) AddMessage(entries []bsmsg.Entry, ses uint64) {
 
 // AddWantlist adds a complete session tracked want list to a message queue
 func (mq *MessageQueue) AddWantlist(initialWants *wantlist.SessionTrackedWantlist) {
-	mq.nextMessageLk.Lock()
-	defer mq.nextMessageLk.Unlock()
-
 	initialWants.CopyWants(mq.wl)
-	if initialWants.Len() > 0 {
-		if mq.nextMessage == nil {
-			mq.nextMessage = bsmsg.New(false)
-		}
-		for _, e := range initialWants.Entries() {
-			mq.nextMessage.AddEntry(e.Cid, e.Priority)
-		}
-		select {
-		case mq.outgoingWork <- struct{}{}:
-		default:
-		}
-	}
+	mq.addWantlist()
+}
+
+// SetRebroadcastInterval sets a new interval on which to rebroadcast the full wantlist
+func (mq *MessageQueue) SetRebroadcastInterval(delay time.Duration) {
+	mq.rebroadcastIntervalLk.Lock()
+	mq.rebroadcastInterval = delay
+	mq.rebroadcastTimer.Reset(delay)
+	mq.rebroadcastIntervalLk.Unlock()
 }
 
 // Startup starts the processing of messages, and creates an initial message
 // based on the given initial wantlist.
 func (mq *MessageQueue) Startup() {
+	mq.rebroadcastIntervalLk.RLock()
+	mq.rebroadcastTimer = time.NewTimer(mq.rebroadcastInterval)
+	mq.rebroadcastIntervalLk.RUnlock()
 	go mq.runQueue()
 }
 
@@ -96,6 +100,8 @@ func (mq *MessageQueue) Shutdown() {
 func (mq *MessageQueue) runQueue() {
 	for {
 		select {
+		case <-mq.rebroadcastTimer.C:
+			mq.rebroadcastWantlist()
 		case <-mq.outgoingWork:
 			mq.sendMessage()
 		case <-mq.done:
@@ -110,6 +116,33 @@ func (mq *MessageQueue) runQueue() {
 			return
 		}
 	}
+}
+
+func (mq *MessageQueue) addWantlist() {
+
+	mq.nextMessageLk.Lock()
+	defer mq.nextMessageLk.Unlock()
+
+	if mq.wl.Len() > 0 {
+		if mq.nextMessage == nil {
+			mq.nextMessage = bsmsg.New(false)
+		}
+		for _, e := range mq.wl.Entries() {
+			mq.nextMessage.AddEntry(e.Cid, e.Priority)
+		}
+		select {
+		case mq.outgoingWork <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func (mq *MessageQueue) rebroadcastWantlist() {
+	mq.rebroadcastIntervalLk.RLock()
+	mq.rebroadcastTimer.Reset(mq.rebroadcastInterval)
+	mq.rebroadcastIntervalLk.RUnlock()
+
+	mq.addWantlist()
 }
 
 func (mq *MessageQueue) addEntries(entries []bsmsg.Entry, ses uint64) bool {

--- a/messagequeue/messagequeue_test.go
+++ b/messagequeue/messagequeue_test.go
@@ -180,9 +180,9 @@ func TestWantlistRebroadcast(t *testing.T) {
 	}
 
 	messageQueue.SetRebroadcastInterval(5 * time.Millisecond)
-	messages = collectMessages(ctx, t, messagesSent, 10*time.Millisecond)
+	messages = collectMessages(ctx, t, messagesSent, 8*time.Millisecond)
 	if len(messages) != 1 {
-		t.Fatal("wrong number of messages were sent for initial wants")
+		t.Fatal("wrong number of messages were rebroadcast")
 	}
 
 	firstMessage := messages[0]


### PR DESCRIPTION
# Goals

Provide a failsafe to losing wants on other end by rebroadcasting a wantlist every thirty seconds

# Implementation

Every peer messagequeue has a rebroadcast timer, which, when it expires, resends all the wants. On the other hand, existing logic in the decision engine will dedup these wants if they are already queued up (see peer request queue)

# For discussion

What's the right interval? I set 30 seconds as a start --- seems long enough to so that there won't be a ton of new network traffic, but short enough that a lost want doesn't mean a super extra long recovery

Do we need something smarter? Or is just rebroadcasting at a regular interval ok? I would be inclined to try this to start, and do something smarter (like rebroadcast if wants sit on the list a long time) later.

fix #99, fix #65