### PR TITLE
Control provider workers with experiment flag

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -51,6 +51,8 @@ const (
 )
 
 var (
+	ProvideEnabled = true
+
 	HasBlockBufferSize    = 256
 	provideKeysBufferSize = 2048
 	provideWorkerMax      = 6
@@ -258,11 +260,13 @@ func (bs *Bitswap) receiveBlockFrom(blk blocks.Block, from peer.ID) error {
 
 	bs.engine.AddBlock(blk)
 
-	select {
-	case bs.newBlocks <- blk.Cid():
-		// send block off to be reprovided
-	case <-bs.process.Closing():
-		return bs.process.Close()
+	if ProvideEnabled {
+		select {
+		case bs.newBlocks <- blk.Cid():
+			// send block off to be reprovided
+		case <-bs.process.Closing():
+			return bs.process.Close()
+		}
 	}
 	return nil
 }

--- a/workers.go
+++ b/workers.go
@@ -23,15 +23,17 @@ func (bs *Bitswap) startWorkers(px process.Process, ctx context.Context) {
 		})
 	}
 
-	// Start up a worker to manage sending out provides messages
-	px.Go(func(px process.Process) {
-		bs.provideCollector(ctx)
-	})
+	if ProvideEnabled {
+		// Start up a worker to manage sending out provides messages
+		px.Go(func(px process.Process) {
+			bs.provideCollector(ctx)
+		})
 
-	// Spawn up multiple workers to handle incoming blocks
-	// consider increasing number if providing blocks bottlenecks
-	// file transfers
-	px.Go(bs.provideWorker)
+		// Spawn up multiple workers to handle incoming blocks
+		// consider increasing number if providing blocks bottlenecks
+		// file transfers
+		px.Go(bs.provideWorker)
+	}
 }
 
 func (bs *Bitswap) taskWorker(ctx context.Context, id int) {


### PR DESCRIPTION
We are working on removing the providing behavior from `go-bitswap` and putting it into its own module in `go-ipfs`. At first the feature will be experimental, and so this commit allows us to disable the provide announcements by setting `bitswap.ProvideEnabled` to `false` before creating bitswap. The default value is `true`.