### PR TITLE
Remove goprocess

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/ipfs/go-ipfs-util v0.0.1
 	github.com/ipfs/go-log v0.0.1
 	github.com/ipfs/go-metrics-interface v0.0.1
-	github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8
 	github.com/libp2p/go-libp2p v0.0.2
 	github.com/libp2p/go-libp2p-host v0.0.1
 	github.com/libp2p/go-libp2p-interface-connmgr v0.0.1
@@ -32,7 +31,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.0.1
 	golang.org/x/crypto v0.0.0-20190506204251-e1dfcc566284 // indirect
 	golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c // indirect
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
 	golang.org/x/sys v0.0.0-20190509141414-a5b02f93d862 // indirect
 	golang.org/x/text v0.3.2 // indirect
-	golang.org/x/tools v0.0.0-20190509153222-73554e0f7805 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -248,7 +248,6 @@ golang.org/x/net v0.0.0-20180524181706-dfa909b99c79/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190227160552-c95aed5357e7 h1:C2F/nMkR/9sfUTpvR3QrjBuTdvMUC/cFajkphs1YLQo=
 golang.org/x/net v0.0.0-20190227160552-c95aed5357e7/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c h1:uOCk1iQW6Vc18bnC13MfzScl+wdKBmM9Y9kU7Z83/lw=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -267,11 +266,10 @@ golang.org/x/sys v0.0.0-20190509141414-a5b02f93d862 h1:rM0ROo5vb9AdYJi1110yjWGMe
 golang.org/x/sys v0.0.0-20190509141414-a5b02f93d862/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/tools v0.0.0-20190509153222-73554e0f7805 h1:1ufBXAsTpUhSmmPXEEs5PrGQSfnBhsjAd2SmVhp9xrY=
-golang.org/x/tools v0.0.0-20190509153222-73554e0f7805/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -1,0 +1,167 @@
+package monitor
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// Monitor starts and monitors closing of tasks, providing mechanisms
+// to wait for tasks to complete. It does not assume contexts as the default
+// waiting mechanism, but can be linked to them
+type Monitor struct {
+	childrenLk      sync.RWMutex
+	children        []childRoutine
+	wg              sync.WaitGroup
+	closeOnce       sync.Once
+	shutdownTimeout time.Duration
+	err             error
+	started         chan struct{}
+	closed          chan struct{}
+	closing         chan struct{}
+}
+
+// New returns a new Monitor with the given timeout duration
+func New(shutdownTimeout time.Duration) *Monitor {
+	return &Monitor{
+		closed:          make(chan struct{}),
+		closing:         make(chan struct{}),
+		started:         make(chan struct{}),
+		shutdownTimeout: shutdownTimeout,
+		children:        make([]childRoutine, 0),
+	}
+}
+
+// Add sets up a task to monitor. It takes three parameters:
+// - a function to start the task
+// - a function to tell the task to stop
+// - a function to wait for a task to fully complete after it's told to stop
+// How the underlying task manages it's internal operations is essentially an
+// unknown
+func (p *Monitor) Add(startFunc func(), stopFunc func(), waitForComplete func()) {
+	p.childrenLk.Lock()
+	defer p.childrenLk.Unlock()
+	p.children = append(p.children, childRoutine{startFunc, stopFunc, waitForComplete})
+	select {
+	case <-p.started:
+		startFunc()
+	default:
+	}
+}
+
+// AddRunnable is a task that is expressed as a function called to start and
+// execute a task to completion, and an interrupt function that can cause the task
+// to terminate.
+func (p *Monitor) AddRunnable(runnable func(), interrupt func()) {
+	completeChan := make(chan struct{})
+	start := func() {
+		go func() {
+			defer close(completeChan)
+			runnable()
+		}()
+	}
+	waitForComplete := func() {
+		<-completeChan
+	}
+	p.Add(start, interrupt, waitForComplete)
+}
+
+// AddCancellable is for tasks that are functions that take a context and run until
+// that context is cancelled.
+func (p *Monitor) AddCancellable(ctx context.Context, cancellable func(context.Context)) {
+	subCtx, subCancel := context.WithCancel(ctx)
+	p.AddRunnable(func() {
+		defer subCancel()
+		cancellable(subCtx)
+	}, subCancel)
+}
+
+// LinkContextCancellation links a monitor to a context, so shutdown the monitor
+// cancels the context and cancelling the context shuts down the monitor
+func (p *Monitor) LinkContextCancellation(ctx context.Context, cancel context.CancelFunc) {
+	go func() {
+		defer cancel()
+		select {
+		case <-p.closing:
+		case <-ctx.Done():
+			p.Shutdown()
+		}
+	}()
+}
+
+// Start initiates tasks given to the monitor. Prior to calling start, added tasks
+// are not started. After calling start, added tasks start as soon as
+// you add them
+func (p *Monitor) Start() {
+	p.childrenLk.RLock()
+	defer p.childrenLk.RUnlock()
+	for _, cr := range p.children {
+		cr.start()
+	}
+	close(p.started)
+}
+
+// Shutdown closes a monitor and waits for its underlying tasks to complete or
+// a timeout to be reached
+func (p *Monitor) Shutdown() error {
+	p.closeOnce.Do(func() {
+		p.childrenLk.RLock()
+		defer p.childrenLk.RUnlock()
+		defer close(p.closed)
+		for _, cr := range p.children {
+			cr.stop()
+		}
+		close(p.closing)
+		p.wg.Add(len(p.children))
+		for _, cr := range p.children {
+			go func(cr childRoutine) {
+				cr.waitForComplete()
+				p.wg.Done()
+			}(cr)
+		}
+		completeChan := make(chan struct{})
+		go func() {
+			defer close(completeChan)
+			p.wg.Wait()
+		}()
+		timeoutChan := func() <-chan time.Time {
+			if p.shutdownTimeout == 0 {
+				return nil
+			}
+			return time.After(p.shutdownTimeout)
+		}
+		select {
+		case <-completeChan:
+		case <-timeoutChan():
+			p.err = errors.New("Timeout Exceeded")
+		}
+	})
+	return p.err
+}
+
+// Closing is a channel that is readable once the monitor has begun closing
+func (p *Monitor) Closing() <-chan struct{} {
+	return p.closing
+}
+
+// Closed is a channel that is readable once the monitor is finished closing
+func (p *Monitor) Closed() <-chan struct{} {
+	return p.closed
+}
+
+// Err is the result of the Shutdown operation, or nil is not errors occurred
+func (p *Monitor) Err() error {
+	select {
+	case <-p.closed:
+		return p.err
+	default:
+		return nil
+	}
+}
+
+type childRoutine struct {
+	start           func()
+	stop            func()
+	waitForComplete func()
+}

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -1,0 +1,208 @@
+package monitor
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestAdding(t *testing.T) {
+	monitor := New(time.Duration(0))
+	var start1Called bool
+	var start2Called bool
+	var start3Called bool
+	var end1Called bool
+	var end2Called bool
+	var end3Called bool
+	var waitForCompletion1Called bool
+	var waitForCompletion2Called bool
+	var waitForCompletion3Called bool
+
+	startFunc1 := func() {
+		start1Called = true
+	}
+	startFunc2 := func() {
+		start2Called = true
+	}
+	startFunc3 := func() {
+		start3Called = true
+	}
+	endFunc1 := func() {
+		end1Called = true
+	}
+	endFunc2 := func() {
+		end2Called = true
+	}
+	endFunc3 := func() {
+		end3Called = true
+	}
+	closingChan1 := make(chan struct{})
+	waitForCompletionFunc1 := func() {
+		<-closingChan1
+		waitForCompletion1Called = true
+	}
+	closingChan2 := make(chan struct{})
+	waitForCompletionFunc2 := func() {
+		<-closingChan2
+		waitForCompletion2Called = true
+	}
+	closingChan3 := make(chan struct{})
+	waitForCompletionFunc3 := func() {
+		<-closingChan3
+		waitForCompletion3Called = true
+	}
+	monitor.Add(startFunc1, endFunc1, waitForCompletionFunc1)
+	monitor.Add(startFunc2, endFunc2, waitForCompletionFunc2)
+
+	if start1Called || start2Called {
+		t.Fatal("Start functions should not start till monitor is started")
+	}
+	monitor.Start()
+	if !start1Called || !start2Called {
+		t.Fatal("Start functions should start once monitor is started")
+	}
+	monitor.Add(startFunc3, endFunc3, waitForCompletionFunc3)
+	if !start3Called {
+		t.Fatal("Tasks added after start should be started immediately")
+	}
+	if end1Called || end2Called || end3Called {
+		t.Fatal("Tasks should not be ended until shutdown is calls")
+	}
+	go monitor.Shutdown()
+
+	<-monitor.Closing()
+	if !end1Called || !end2Called || !end3Called {
+		t.Fatal("Tasks should have been told to begin closing once shutdown is called")
+	}
+	if waitForCompletion1Called || waitForCompletion2Called || waitForCompletion3Called {
+		t.Fatal("Completion should not have happened until channel is closed")
+	}
+	close(closingChan1)
+	close(closingChan2)
+	close(closingChan3)
+	<-monitor.Closed()
+	if !waitForCompletion1Called || !waitForCompletion2Called || !waitForCompletion3Called {
+		t.Fatal("Completion should have happened once channel is closed")
+	}
+}
+
+func TestShutdownTimeout(t *testing.T) {
+	startFunc := func() {}
+	endFunc := func() {}
+	closingChan := make(chan struct{})
+	waitForCompletionFunc := func() {
+		<-closingChan
+	}
+
+	monitor := New(10 * time.Millisecond)
+	monitor.Add(startFunc, endFunc, waitForCompletionFunc)
+
+	monitor.Start()
+
+	go monitor.Shutdown()
+
+	select {
+	case <-time.After(10 * time.Second):
+		t.Fatal("Shutdown should have timed out but did not")
+	case <-monitor.Closed():
+		close(closingChan)
+	}
+}
+
+func TestAddCancellable(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	monitor := New(time.Duration(0))
+	completed1 := make(chan struct{})
+	monitor.AddCancellable(ctx, func(subCtx context.Context) {
+		<-subCtx.Done()
+		close(completed1)
+	})
+	completed2 := make(chan struct{})
+	subCtx2, subCancel := context.WithCancel(ctx)
+	monitor.AddCancellable(subCtx2, func(subCtx context.Context) {
+		<-subCtx.Done()
+		close(completed2)
+	})
+	monitor.Start()
+	// can cancel via context
+	subCancel()
+	select {
+	case <-ctx.Done():
+		t.Fatal("Should have cancelled monitored process but did not")
+	case <-completed2:
+	}
+
+	// can cancel via shutdown
+	monitor.Shutdown()
+	select {
+	case <-ctx.Done():
+		t.Fatal("Should have cancelled monitored process but did not")
+	case <-completed1:
+	}
+}
+
+func TestRunnable(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	completed := make(chan struct{})
+	interrupted := make(chan struct{})
+	started := make(chan struct{})
+	monitor := New(time.Duration(0))
+	monitor.AddRunnable(func() {
+		close(started)
+		<-interrupted
+		close(completed)
+	}, func() { close(interrupted) })
+	monitor.Start()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("runnable function should have been started but was not")
+	case <-started:
+	}
+
+	select {
+	case <-interrupted:
+		t.Fatal("process should not be interrupted")
+	case <-completed:
+		t.Fatal("process should not be completed")
+	default:
+	}
+
+	monitor.Shutdown()
+	select {
+	case <-ctx.Done():
+		t.Fatal("runnable function should have been completed but was not")
+	case <-completed:
+	}
+}
+
+func TestLinkWithCancellableContext(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	monitor := New(time.Duration(0))
+	subCtx1, subCancel1 := context.WithCancel(ctx)
+	monitor.LinkContextCancellation(subCtx1, subCancel1)
+	subCtx2, subCancel2 := context.WithCancel(context.Background())
+	defer subCancel2()
+	monitor.LinkContextCancellation(subCtx2, subCancel2)
+	subCancel1()
+	monitor.Start()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Process should have closed from linked context cancellation but did not")
+	case <-monitor.Closed():
+	}
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("linked context should have cancelled from process closing but didn't")
+	case <-subCtx2.Done():
+	}
+}


### PR DESCRIPTION
# Goals

This change removes goprocess to reduce the learning curve for new people coming in to working on go-bitswap. While goprocess is a really cool library, it's non-standard, and it's partial implementation in go-bitswap, unique as I understand it to the IPFS codebase, increases confusion in the bitswap codebase. I remember losing at least a day to figuring out what it is and whether it should be there when I first started on go-bitswap. We're really not using it for anything special, other than to cancel some go routines, for which contexts are adequate.

We did have a broader conversation about go routine supervision in go-ipfs, but came to the conclusion that at least for the moment we're using just contexts.

# Implementation

- Remove go-process, replace with context cancellation code where neccesary.