### PR TITLE
feat(sessions): add rebroadcasting, search backoff

### DIFF
--- a/bitswap_test.go
+++ b/bitswap_test.go
@@ -102,11 +102,9 @@ func TestGetBlockFromPeerAfterPeerAnnounces(t *testing.T) {
 }
 
 func TestDoesNotProvideWhenConfiguredNotTo(t *testing.T) {
-	bssession.SetProviderSearchDelay(50 * time.Millisecond)
-	defer bssession.SetProviderSearchDelay(time.Second)
 	net := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(kNetworkDelay))
 	block := blocks.NewBlock([]byte("block"))
-	ig := testinstance.NewTestInstanceGenerator(net, bitswap.ProvideEnabled(false))
+	ig := testinstance.NewTestInstanceGenerator(net, bitswap.ProvideEnabled(false), bitswap.ProviderSearchDelay(50*time.Millisecond))
 	defer ig.Close()
 
 	hasBlock := ig.Next()

--- a/bitswap_with_sessions_test.go
+++ b/bitswap_with_sessions_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	bitswap "github.com/ipfs/go-bitswap"
 	bssession "github.com/ipfs/go-bitswap/session"
 	testinstance "github.com/ipfs/go-bitswap/testinstance"
 	blocks "github.com/ipfs/go-block-format"
@@ -161,9 +162,8 @@ func TestFetchNotConnected(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	bssession.SetProviderSearchDelay(10 * time.Millisecond)
 	vnet := getVirtualNetwork()
-	ig := testinstance.NewTestInstanceGenerator(vnet)
+	ig := testinstance.NewTestInstanceGenerator(vnet, bitswap.ProviderSearchDelay(10*time.Millisecond))
 	defer ig.Close()
 	bgen := blocksutil.NewBlockGenerator()
 

--- a/session/session.go
+++ b/session/session.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -341,7 +340,6 @@ func (s *Session) handleTick(ctx context.Context) {
 }
 
 func (s *Session) handleRebroadcast(ctx context.Context) {
-	fmt.Println("Rebroadcast")
 
 	if len(s.liveWants) == 0 {
 		return

--- a/session/session.go
+++ b/session/session.go
@@ -314,10 +314,12 @@ func (s *Session) handleCancel(keys []cid.Cid) {
 
 func (s *Session) handleTick(ctx context.Context) {
 
-	if s.fetchcnt == s.lastFetchCount {
-		s.consecutiveTicks++
-	} else {
-		s.lastFetchCount = s.fetchcnt
+	if len(s.liveWants) > 0 {
+		if s.fetchcnt == s.lastFetchCount {
+			s.consecutiveTicks++
+		} else {
+			s.lastFetchCount = s.fetchcnt
+		}
 	}
 
 	live := make([]cid.Cid, 0, len(s.liveWants))

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -84,7 +84,7 @@ func TestSessionGetBlocks(t *testing.T) {
 	fpm := &fakePeerManager{}
 	frs := &fakeRequestSplitter{}
 	id := testutil.GenerateSessionID()
-	session := New(ctx, id, fwm, fpm, frs)
+	session := New(ctx, id, fwm, fpm, frs, time.Second, delay.Fixed(time.Minute))
 	blockGenerator := blocksutil.NewBlockGenerator()
 	blks := blockGenerator.Blocks(broadcastLiveWantsLimit * 2)
 	var cids []cid.Cid
@@ -196,7 +196,7 @@ func TestSessionFindMorePeers(t *testing.T) {
 	fpm := &fakePeerManager{findMorePeersRequested: make(chan cid.Cid, 1)}
 	frs := &fakeRequestSplitter{}
 	id := testutil.GenerateSessionID()
-	session := New(ctx, id, fwm, fpm, frs)
+	session := New(ctx, id, fwm, fpm, frs, time.Second, delay.Fixed(time.Minute))
 	session.SetBaseTickDelay(200 * time.Microsecond)
 	blockGenerator := blocksutil.NewBlockGenerator()
 	blks := blockGenerator.Blocks(broadcastLiveWantsLimit * 2)
@@ -260,11 +260,6 @@ func TestSessionFindMorePeers(t *testing.T) {
 }
 
 func TestSessionFailingToGetFirstBlock(t *testing.T) {
-	SetProviderSearchDelay(10 * time.Millisecond)
-	defer SetProviderSearchDelay(1 * time.Second)
-	SetRebroadcastDelay(delay.Fixed(100 * time.Millisecond))
-	defer SetRebroadcastDelay(delay.Fixed(1 * time.Minute))
-
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	wantReqs := make(chan wantReq, 1)
@@ -274,7 +269,7 @@ func TestSessionFailingToGetFirstBlock(t *testing.T) {
 	frs := &fakeRequestSplitter{}
 	id := testutil.GenerateSessionID()
 
-	session := New(ctx, id, fwm, fpm, frs)
+	session := New(ctx, id, fwm, fpm, frs, 10*time.Millisecond, delay.Fixed(100*time.Millisecond))
 	blockGenerator := blocksutil.NewBlockGenerator()
 	blks := blockGenerator.Blocks(4)
 	var cids []cid.Cid

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -260,8 +260,12 @@ func TestSessionFindMorePeers(t *testing.T) {
 }
 
 func TestSessionFailingToGetFirstBlock(t *testing.T) {
+	SetProviderSearchDelay(10 * time.Millisecond)
+	defer SetProviderSearchDelay(1 * time.Second)
+	SetRebroadcastDelay(delay.Fixed(100 * time.Millisecond))
+	defer SetRebroadcastDelay(delay.Fixed(1 * time.Minute))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 900*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	wantReqs := make(chan wantReq, 1)
 	cancelReqs := make(chan wantReq, 1)
@@ -269,10 +273,7 @@ func TestSessionFailingToGetFirstBlock(t *testing.T) {
 	fpm := &fakePeerManager{findMorePeersRequested: make(chan cid.Cid, 1)}
 	frs := &fakeRequestSplitter{}
 	id := testutil.GenerateSessionID()
-	SetProviderSearchDelay(10 * time.Millisecond)
-	defer SetProviderSearchDelay(1 * time.Second)
-	SetRebroadcastDelay(delay.Fixed(100 * time.Millisecond))
-	defer SetRebroadcastDelay(delay.Fixed(1 * time.Minute))
+
 	session := New(ctx, id, fwm, fpm, frs)
 	blockGenerator := blocksutil.NewBlockGenerator()
 	blks := blockGenerator.Blocks(4)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-block-format"
-
 	bssrs "github.com/ipfs/go-bitswap/sessionrequestsplitter"
 	"github.com/ipfs/go-bitswap/testutil"
+	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
+	delay "github.com/ipfs/go-ipfs-delay"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -42,12 +42,12 @@ func (fwm *fakeWantManager) CancelWants(ctx context.Context, cids []cid.Cid, pee
 type fakePeerManager struct {
 	lk                     sync.RWMutex
 	peers                  []peer.ID
-	findMorePeersRequested chan struct{}
+	findMorePeersRequested chan cid.Cid
 }
 
 func (fpm *fakePeerManager) FindMorePeers(ctx context.Context, k cid.Cid) {
 	select {
-	case fpm.findMorePeersRequested <- struct{}{}:
+	case fpm.findMorePeersRequested <- k:
 	case <-ctx.Done():
 	}
 }
@@ -193,7 +193,7 @@ func TestSessionFindMorePeers(t *testing.T) {
 	wantReqs := make(chan wantReq, 1)
 	cancelReqs := make(chan wantReq, 1)
 	fwm := &fakeWantManager{wantReqs, cancelReqs}
-	fpm := &fakePeerManager{findMorePeersRequested: make(chan struct{}, 1)}
+	fpm := &fakePeerManager{findMorePeersRequested: make(chan cid.Cid, 1)}
 	frs := &fakeRequestSplitter{}
 	id := testutil.GenerateSessionID()
 	session := New(ctx, id, fwm, fpm, frs)
@@ -256,5 +256,130 @@ func TestSessionFindMorePeers(t *testing.T) {
 	case <-fpm.findMorePeersRequested:
 	case <-ctx.Done():
 		t.Fatal("Did not find more peers")
+	}
+}
+
+func TestSessionFailingToGetFirstBlock(t *testing.T) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 900*time.Millisecond)
+	defer cancel()
+	wantReqs := make(chan wantReq, 1)
+	cancelReqs := make(chan wantReq, 1)
+	fwm := &fakeWantManager{wantReqs, cancelReqs}
+	fpm := &fakePeerManager{findMorePeersRequested: make(chan cid.Cid, 1)}
+	frs := &fakeRequestSplitter{}
+	id := testutil.GenerateSessionID()
+	SetProviderSearchDelay(10 * time.Millisecond)
+	defer SetProviderSearchDelay(1 * time.Second)
+	SetRebroadcastDelay(delay.Fixed(100 * time.Millisecond))
+	defer SetRebroadcastDelay(delay.Fixed(1 * time.Minute))
+	session := New(ctx, id, fwm, fpm, frs)
+	blockGenerator := blocksutil.NewBlockGenerator()
+	blks := blockGenerator.Blocks(4)
+	var cids []cid.Cid
+	for _, block := range blks {
+		cids = append(cids, block.Cid())
+	}
+	startTick := time.Now()
+	_, err := session.GetBlocks(ctx, cids)
+	if err != nil {
+		t.Fatal("error getting blocks")
+	}
+
+	// clear the initial block of wants
+	select {
+	case <-wantReqs:
+	case <-ctx.Done():
+		t.Fatal("Did not make first want request ")
+	}
+
+	// verify a broadcast is made
+	select {
+	case receivedWantReq := <-wantReqs:
+		if len(receivedWantReq.cids) < len(cids) {
+			t.Fatal("did not rebroadcast whole live list")
+		}
+		if receivedWantReq.peers != nil {
+			t.Fatal("did not make a broadcast")
+		}
+	case <-ctx.Done():
+		t.Fatal("Never rebroadcast want list")
+	}
+
+	// wait for a request to get more peers to occur
+	select {
+	case k := <-fpm.findMorePeersRequested:
+		if testutil.IndexOf(blks, k) == -1 {
+			t.Fatal("did not rebroadcast an active want")
+		}
+	case <-ctx.Done():
+		t.Fatal("Did not find more peers")
+	}
+	firstTickLength := time.Since(startTick)
+
+	// wait for another broadcast to occur
+	select {
+	case receivedWantReq := <-wantReqs:
+		if len(receivedWantReq.cids) < len(cids) {
+			t.Fatal("did not rebroadcast whole live list")
+		}
+		if receivedWantReq.peers != nil {
+			t.Fatal("did not make a broadcast")
+		}
+	case <-ctx.Done():
+		t.Fatal("Never rebroadcast want list")
+	}
+	startTick = time.Now()
+	// wait for another broadcast to occur
+	select {
+	case receivedWantReq := <-wantReqs:
+		if len(receivedWantReq.cids) < len(cids) {
+			t.Fatal("did not rebroadcast whole live list")
+		}
+		if receivedWantReq.peers != nil {
+			t.Fatal("did not make a broadcast")
+		}
+	case <-ctx.Done():
+		t.Fatal("Never rebroadcast want list")
+	}
+	consecutiveTickLength := time.Since(startTick)
+	// tick should take longer
+	if firstTickLength > consecutiveTickLength {
+		t.Fatal("Should have increased tick length after first consecutive tick")
+	}
+	startTick = time.Now()
+	// wait for another broadcast to occur
+	select {
+	case receivedWantReq := <-wantReqs:
+		if len(receivedWantReq.cids) < len(cids) {
+			t.Fatal("did not rebroadcast whole live list")
+		}
+		if receivedWantReq.peers != nil {
+			t.Fatal("did not make a broadcast")
+		}
+	case <-ctx.Done():
+		t.Fatal("Never rebroadcast want list")
+	}
+	secondConsecutiveTickLength := time.Since(startTick)
+	// tick should take longer
+	if consecutiveTickLength > secondConsecutiveTickLength {
+		t.Fatal("Should have increased tick length after first consecutive tick")
+	}
+
+	// should not have looked for peers on consecutive ticks
+	select {
+	case <-fpm.findMorePeersRequested:
+		t.Fatal("Should not have looked for peers on consecutive tick")
+	default:
+	}
+
+	// wait for rebroadcast to occur
+	select {
+	case k := <-fpm.findMorePeersRequested:
+		if testutil.IndexOf(blks, k) == -1 {
+			t.Fatal("did not rebroadcast an active want")
+		}
+	case <-ctx.Done():
+		t.Fatal("Did not rebroadcast to find more peers")
 	}
 }

--- a/sessionmanager/sessionmanager.go
+++ b/sessionmanager/sessionmanager.go
@@ -3,9 +3,11 @@ package sessionmanager
 import (
 	"context"
 	"sync"
+	"time"
 
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
+	delay "github.com/ipfs/go-ipfs-delay"
 
 	bssession "github.com/ipfs/go-bitswap/session"
 	exchange "github.com/ipfs/go-ipfs-exchange-interface"
@@ -27,7 +29,7 @@ type sesTrk struct {
 }
 
 // SessionFactory generates a new session for the SessionManager to track.
-type SessionFactory func(ctx context.Context, id uint64, pm bssession.PeerManager, srs bssession.RequestSplitter) Session
+type SessionFactory func(ctx context.Context, id uint64, pm bssession.PeerManager, srs bssession.RequestSplitter, provSearchDelay time.Duration, rebroadcastDelay delay.D) Session
 
 // RequestSplitterFactory generates a new request splitter for a session.
 type RequestSplitterFactory func(ctx context.Context) bssession.RequestSplitter
@@ -64,13 +66,15 @@ func New(ctx context.Context, sessionFactory SessionFactory, peerManagerFactory 
 
 // NewSession initializes a session with the given context, and adds to the
 // session manager.
-func (sm *SessionManager) NewSession(ctx context.Context) exchange.Fetcher {
+func (sm *SessionManager) NewSession(ctx context.Context,
+	provSearchDelay time.Duration,
+	rebroadcastDelay delay.D) exchange.Fetcher {
 	id := sm.GetNextSessionID()
 	sessionctx, cancel := context.WithCancel(ctx)
 
 	pm := sm.peerManagerFactory(sessionctx, id)
 	srs := sm.requestSplitterFactory(sessionctx)
-	session := sm.sessionFactory(sessionctx, id, pm, srs)
+	session := sm.sessionFactory(sessionctx, id, pm, srs, provSearchDelay, rebroadcastDelay)
 	tracked := sesTrk{session, pm, srs}
 	sm.sessLk.Lock()
 	sm.sessions = append(sm.sessions, tracked)


### PR DESCRIPTION
# Goals

Attempt to kill two birds with one stone:
1. Don't keep making requests for more providers for the same block (even thought they are already deduped in the provider query manager, still fires off a spurious go-routine in the SessionPeerManager) (#107 )
2. Periodically search for more providers (#95 )

# Implemenation

Start tracking whether a tick is "consecutive" -- i.e no new unique blocks have been received since the last tick. On consecutive ticks do two things different:
1. Don't kick off another request for providers
2. Gradually back off the time till the next tick -- cause each tick rebroadcasts the whole want list, which is often expensive. Multiple consecutive ticks essentially mean whatever the session is being used for has largely stalled, so minimize usage just for this.

It might be a problem to never go looking for providers for the same block again but...

By adding a very periodic search for more providers no matter what (i.e. 1 minute -- mirroring the rebroadcast time in pre-sessions bitswap), there is a last ditch insurance policy that you'll keep looking for providers just in case they appear.

And, as a bonus, this means if you are receiving blocks but have slow providers, eventually you'll go looking for faster ones.

Ideally:
fix #95, fix #107

# For discussion

At this point, the global options SetProviderSearchDelay & SetRebroadcastDelay are starting to get to be a smell (need options on sessions) and need a refactor but this is a subtle enough change I wanted it evaluated on its own.