### PR TITLE
WIP improve provider request rate limiting

### DIFF
--- a/providerquerymanager/providerquerymanager_test.go
+++ b/providerquerymanager/providerquerymanager_test.go
@@ -243,7 +243,7 @@ func TestPeersWithConnectionErrorsNotAddedToPeerList(t *testing.T) {
 
 }
 
-func TestRateLimitingRequests(t *testing.T) {
+/*func TestRateLimitingRequests(t *testing.T) {
 	peers := testutil.GeneratePeers(10)
 	fpn := &fakeProviderNetwork{
 		peersFound: peers,
@@ -279,7 +279,7 @@ func TestRateLimitingRequests(t *testing.T) {
 	if fpn.queriesMade != maxInProcessRequests+1 {
 		t.Fatal("Did not make all seperate requests")
 	}
-}
+}*/
 
 func TestFindProviderTimeout(t *testing.T) {
 	peers := testutil.GeneratePeers(10)


### PR DESCRIPTION
# Goal

The Gateway is having issues seemingly due to getting backed up looking for more providers for requests.

# Implementation

-- So far, just remove rate limit on simultaneous requests for more providers completely in this branch -- which we will deploy to the gateway to test efficacy.
-- if successful, we will decide on an optimal strategy and implement