### PR TITLE
fix(decision): remove peer task queue package

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -129,7 +129,7 @@ func New(parent context.Context, network bsnet.BitSwapNetwork,
 
 	bs := &Bitswap{
 		blockstore:       bstore,
-		engine:           decision.NewEngine(ctx, bstore, network.ConnectionManager()), // TODO close the engine with Close() method
+		engine:           decision.NewEngine(ctx, bstore), // TODO close the engine with Close() method
 		network:          network,
 		process:          px,
 		newBlocks:        make(chan cid.Cid, HasBlockBufferSize),

--- a/decision/bench_test.go
+++ b/decision/bench_test.go
@@ -1,0 +1,30 @@
+package decision
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/ipfs/go-bitswap/wantlist"
+	cid "github.com/ipfs/go-cid"
+	u "github.com/ipfs/go-ipfs-util"
+	"github.com/libp2p/go-libp2p-core/peer"
+	testutil "github.com/libp2p/go-libp2p-core/test"
+)
+
+// FWIW: At the time of this commit, including a timestamp in task increases
+// time cost of Push by 3%.
+func BenchmarkTaskQueuePush(b *testing.B) {
+	q := newPRQ()
+	peers := []peer.ID{
+		testutil.RandPeerIDFatal(b),
+		testutil.RandPeerIDFatal(b),
+		testutil.RandPeerIDFatal(b),
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := cid.NewCidV0(u.Hash([]byte(fmt.Sprint(i))))
+
+		q.Push(peers[i%len(peers)], wantlist.Entry{Cid: c, Priority: math.MaxInt32})
+	}
+}

--- a/decision/engine_test.go
+++ b/decision/engine_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	message "github.com/ipfs/go-bitswap/message"
 
@@ -19,57 +18,17 @@ import (
 	testutil "github.com/libp2p/go-libp2p-core/test"
 )
 
-type fakePeerTagger struct {
-	lk          sync.Mutex
-	wait        sync.WaitGroup
-	taggedPeers []peer.ID
+type peerAndEngine struct {
+	Peer   peer.ID
+	Engine *Engine
 }
 
-func (fpt *fakePeerTagger) TagPeer(p peer.ID, tag string, n int) {
-	fpt.wait.Add(1)
-
-	fpt.lk.Lock()
-	defer fpt.lk.Unlock()
-	fpt.taggedPeers = append(fpt.taggedPeers, p)
-}
-
-func (fpt *fakePeerTagger) UntagPeer(p peer.ID, tag string) {
-	defer fpt.wait.Done()
-
-	fpt.lk.Lock()
-	defer fpt.lk.Unlock()
-	for i := 0; i < len(fpt.taggedPeers); i++ {
-		if fpt.taggedPeers[i] == p {
-			fpt.taggedPeers[i] = fpt.taggedPeers[len(fpt.taggedPeers)-1]
-			fpt.taggedPeers = fpt.taggedPeers[:len(fpt.taggedPeers)-1]
-			return
-		}
-	}
-}
-
-func (fpt *fakePeerTagger) count() int {
-	fpt.lk.Lock()
-	defer fpt.lk.Unlock()
-	return len(fpt.taggedPeers)
-}
-
-type engineSet struct {
-	PeerTagger *fakePeerTagger
-	Peer       peer.ID
-	Engine     *Engine
-	Blockstore blockstore.Blockstore
-}
-
-func newEngine(ctx context.Context, idStr string) engineSet {
-	fpt := &fakePeerTagger{}
-	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
-	return engineSet{
+func newEngine(ctx context.Context, idStr string) peerAndEngine {
+	return peerAndEngine{
 		Peer: peer.ID(idStr),
 		//Strategy: New(true),
-		PeerTagger: fpt,
-		Blockstore: bs,
 		Engine: NewEngine(ctx,
-			bs, fpt),
+			blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))),
 	}
 }
 
@@ -148,7 +107,7 @@ func peerIsPartner(p peer.ID, e *Engine) bool {
 
 func TestOutboxClosedWhenEngineClosed(t *testing.T) {
 	t.SkipNow() // TODO implement *Engine.Close
-	e := NewEngine(context.Background(), blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore())), &fakePeerTagger{})
+	e := NewEngine(context.Background(), blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore())))
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -205,7 +164,7 @@ func TestPartnerWantsThenCancels(t *testing.T) {
 
 	for i := 0; i < numRounds; i++ {
 		expected := make([][]string, 0, len(testcases))
-		e := NewEngine(context.Background(), bs, &fakePeerTagger{})
+		e := NewEngine(context.Background(), bs)
 		for _, testcase := range testcases {
 			set := testcase[0]
 			cancels := testcase[1]
@@ -224,33 +183,6 @@ func TestPartnerWantsThenCancels(t *testing.T) {
 	}
 }
 
-func TestTaggingPeers(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	sanfrancisco := newEngine(ctx, "sf")
-	seattle := newEngine(ctx, "sea")
-
-	keys := []string{"a", "b", "c", "d", "e"}
-	for _, letter := range keys {
-		block := blocks.NewBlock([]byte(letter))
-		if err := sanfrancisco.Blockstore.Put(block); err != nil {
-			t.Fatal(err)
-		}
-	}
-	partnerWants(sanfrancisco.Engine, keys, seattle.Peer)
-	next := <-sanfrancisco.Engine.Outbox()
-	envelope := <-next
-
-	if sanfrancisco.PeerTagger.count() != 1 {
-		t.Fatal("Incorrect number of peers tagged")
-	}
-	envelope.Sent()
-	next = <-sanfrancisco.Engine.Outbox()
-	sanfrancisco.PeerTagger.wait.Wait()
-	if sanfrancisco.PeerTagger.count() != 0 {
-		t.Fatal("Peers should be untagged but weren't")
-	}
-}
 func partnerWants(e *Engine, keys []string, partner peer.ID) {
 	add := message.New(false)
 	for i, letter := range keys {

--- a/decision/peer_request_queue.go
+++ b/decision/peer_request_queue.go
@@ -1,0 +1,356 @@
+package decision
+
+import (
+	"sync"
+	"time"
+
+	wantlist "github.com/ipfs/go-bitswap/wantlist"
+
+	cid "github.com/ipfs/go-cid"
+	pq "github.com/ipfs/go-ipfs-pq"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+)
+
+type peerRequestQueue interface {
+	// Pop returns the next peerRequestTask. Returns nil if the peerRequestQueue is empty.
+	Pop() *peerRequestTask
+	Push(to peer.ID, entries ...wantlist.Entry)
+	Remove(k cid.Cid, p peer.ID)
+
+	// NB: cannot expose simply expose taskQueue.Len because trashed elements
+	// may exist. These trashed elements should not contribute to the count.
+}
+
+func newPRQ() *prq {
+	return &prq{
+		taskMap:  make(map[taskEntryKey]*peerRequestTask),
+		partners: make(map[peer.ID]*activePartner),
+		frozen:   make(map[peer.ID]*activePartner),
+		pQueue:   pq.New(partnerCompare),
+	}
+}
+
+// verify interface implementation
+var _ peerRequestQueue = &prq{}
+
+// TODO: at some point, the strategy needs to plug in here
+// to help decide how to sort tasks (on add) and how to select
+// tasks (on getnext). For now, we are assuming a dumb/nice strategy.
+type prq struct {
+	lock     sync.Mutex
+	pQueue   pq.PQ
+	taskMap  map[taskEntryKey]*peerRequestTask
+	partners map[peer.ID]*activePartner
+
+	frozen map[peer.ID]*activePartner
+}
+
+// Push currently adds a new peerRequestTask to the end of the list.
+func (tl *prq) Push(to peer.ID, entries ...wantlist.Entry) {
+	tl.lock.Lock()
+	defer tl.lock.Unlock()
+	partner, ok := tl.partners[to]
+	if !ok {
+		partner = newActivePartner(to)
+		tl.pQueue.Push(partner)
+		tl.partners[to] = partner
+	}
+
+	partner.activelk.Lock()
+	defer partner.activelk.Unlock()
+
+	var priority int
+	newEntries := make([]peerRequestTaskEntry, 0, len(entries))
+	for _, entry := range entries {
+		if partner.activeBlocks.Has(entry.Cid) {
+			continue
+		}
+		if task, ok := tl.taskMap[taskEntryKey{to, entry.Cid}]; ok {
+			if entry.Priority > task.Priority {
+				task.Priority = entry.Priority
+				partner.taskQueue.Update(task.index)
+			}
+			continue
+		}
+		if entry.Priority > priority {
+			priority = entry.Priority
+		}
+		newEntries = append(newEntries, peerRequestTaskEntry{entry, false})
+	}
+
+	if len(newEntries) == 0 {
+		return
+	}
+
+	task := &peerRequestTask{
+		Entries: newEntries,
+		Target:  to,
+		created: time.Now(),
+		Done: func(e []peerRequestTaskEntry) {
+			tl.lock.Lock()
+			for _, entry := range e {
+				partner.TaskDone(entry.Cid)
+			}
+			tl.pQueue.Update(partner.Index())
+			tl.lock.Unlock()
+		},
+	}
+	task.Priority = priority
+	partner.taskQueue.Push(task)
+	for _, entry := range newEntries {
+		tl.taskMap[taskEntryKey{to, entry.Cid}] = task
+	}
+	partner.requests += len(newEntries)
+	tl.pQueue.Update(partner.Index())
+}
+
+// Pop 'pops' the next task to be performed. Returns nil if no task exists.
+func (tl *prq) Pop() *peerRequestTask {
+	tl.lock.Lock()
+	defer tl.lock.Unlock()
+	if tl.pQueue.Len() == 0 {
+		return nil
+	}
+	partner := tl.pQueue.Pop().(*activePartner)
+
+	var out *peerRequestTask
+	for partner.taskQueue.Len() > 0 && partner.freezeVal == 0 {
+		out = partner.taskQueue.Pop().(*peerRequestTask)
+
+		newEntries := make([]peerRequestTaskEntry, 0, len(out.Entries))
+		for _, entry := range out.Entries {
+			delete(tl.taskMap, taskEntryKey{out.Target, entry.Cid})
+			if entry.trash {
+				continue
+			}
+			partner.requests--
+			partner.StartTask(entry.Cid)
+			newEntries = append(newEntries, entry)
+		}
+		if len(newEntries) > 0 {
+			out.Entries = newEntries
+		} else {
+			out = nil // discarding tasks that have been removed
+			continue
+		}
+		break // and return |out|
+	}
+
+	if partner.IsIdle() {
+		target := partner.target
+		delete(tl.partners, target)
+		delete(tl.frozen, target)
+	} else {
+		tl.pQueue.Push(partner)
+	}
+	return out
+}
+
+// Remove removes a task from the queue.
+func (tl *prq) Remove(k cid.Cid, p peer.ID) {
+	tl.lock.Lock()
+	t, ok := tl.taskMap[taskEntryKey{p, k}]
+	if ok {
+		for i := range t.Entries {
+			if t.Entries[i].Cid.Equals(k) {
+				// remove the task "lazily"
+				// simply mark it as trash, so it'll be dropped when popped off the
+				// queue.
+				t.Entries[i].trash = true
+				break
+			}
+		}
+
+		// having canceled a block, we now account for that in the given partner
+		partner := tl.partners[p]
+		partner.requests--
+
+		// we now also 'freeze' that partner. If they sent us a cancel for a
+		// block we were about to send them, we should wait a short period of time
+		// to make sure we receive any other in-flight cancels before sending
+		// them a block they already potentially have
+		if partner.freezeVal == 0 {
+			tl.frozen[p] = partner
+		}
+
+		partner.freezeVal++
+		tl.pQueue.Update(partner.index)
+	}
+	tl.lock.Unlock()
+}
+
+func (tl *prq) fullThaw() {
+	tl.lock.Lock()
+	defer tl.lock.Unlock()
+
+	for id, partner := range tl.frozen {
+		partner.freezeVal = 0
+		delete(tl.frozen, id)
+		tl.pQueue.Update(partner.index)
+	}
+}
+
+func (tl *prq) thawRound() {
+	tl.lock.Lock()
+	defer tl.lock.Unlock()
+
+	for id, partner := range tl.frozen {
+		partner.freezeVal -= (partner.freezeVal + 1) / 2
+		if partner.freezeVal <= 0 {
+			delete(tl.frozen, id)
+		}
+		tl.pQueue.Update(partner.index)
+	}
+}
+
+type peerRequestTaskEntry struct {
+	wantlist.Entry
+	// trash in a book-keeping field
+	trash bool
+}
+type peerRequestTask struct {
+	Entries  []peerRequestTaskEntry
+	Priority int
+	Target   peer.ID
+
+	// A callback to signal that this task has been completed
+	Done func([]peerRequestTaskEntry)
+
+	// created marks the time that the task was added to the queue
+	created time.Time
+	index   int // book-keeping field used by the pq container
+}
+
+// Index implements pq.Elem.
+func (t *peerRequestTask) Index() int {
+	return t.index
+}
+
+// SetIndex implements pq.Elem.
+func (t *peerRequestTask) SetIndex(i int) {
+	t.index = i
+}
+
+// taskEntryKey is a key identifying a task.
+type taskEntryKey struct {
+	p peer.ID
+	k cid.Cid
+}
+
+// FIFO is a basic task comparator that returns tasks in the order created.
+var FIFO = func(a, b *peerRequestTask) bool {
+	return a.created.Before(b.created)
+}
+
+// V1 respects the target peer's wantlist priority. For tasks involving
+// different peers, the oldest task is prioritized.
+var V1 = func(a, b *peerRequestTask) bool {
+	if a.Target == b.Target {
+		return a.Priority > b.Priority
+	}
+	return FIFO(a, b)
+}
+
+func wrapCmp(f func(a, b *peerRequestTask) bool) func(a, b pq.Elem) bool {
+	return func(a, b pq.Elem) bool {
+		return f(a.(*peerRequestTask), b.(*peerRequestTask))
+	}
+}
+
+type activePartner struct {
+	target peer.ID
+	// Active is the number of blocks this peer is currently being sent
+	// active must be locked around as it will be updated externally
+	activelk sync.Mutex
+	active   int
+
+	activeBlocks *cid.Set
+
+	// requests is the number of blocks this peer is currently requesting
+	// request need not be locked around as it will only be modified under
+	// the peerRequestQueue's locks
+	requests int
+
+	// for the PQ interface
+	index int
+
+	freezeVal int
+
+	// priority queue of tasks belonging to this peer
+	taskQueue pq.PQ
+}
+
+func newActivePartner(target peer.ID) *activePartner {
+	return &activePartner{
+		target:       target,
+		taskQueue:    pq.New(wrapCmp(V1)),
+		activeBlocks: cid.NewSet(),
+	}
+}
+
+// partnerCompare implements pq.ElemComparator
+// returns true if peer 'a' has higher priority than peer 'b'
+func partnerCompare(a, b pq.Elem) bool {
+	pa := a.(*activePartner)
+	pb := b.(*activePartner)
+
+	// having no blocks in their wantlist means lowest priority
+	// having both of these checks ensures stability of the sort
+	if pa.requests == 0 {
+		return false
+	}
+	if pb.requests == 0 {
+		return true
+	}
+
+	if pa.freezeVal > pb.freezeVal {
+		return false
+	}
+	if pa.freezeVal < pb.freezeVal {
+		return true
+	}
+
+	if pa.active == pb.active {
+		// sorting by taskQueue.Len() aids in cleaning out trash entries faster
+		// if we sorted instead by requests, one peer could potentially build up
+		// a huge number of cancelled entries in the queue resulting in a memory leak
+		return pa.taskQueue.Len() > pb.taskQueue.Len()
+	}
+	return pa.active < pb.active
+}
+
+// StartTask signals that a task was started for this partner.
+func (p *activePartner) StartTask(k cid.Cid) {
+	p.activelk.Lock()
+	p.activeBlocks.Add(k)
+	p.active++
+	p.activelk.Unlock()
+}
+
+// TaskDone signals that a task was completed for this partner.
+func (p *activePartner) TaskDone(k cid.Cid) {
+	p.activelk.Lock()
+
+	p.activeBlocks.Remove(k)
+	p.active--
+	if p.active < 0 {
+		panic("more tasks finished than started!")
+	}
+	p.activelk.Unlock()
+}
+
+func (p *activePartner) IsIdle() bool {
+	p.activelk.Lock()
+	defer p.activelk.Unlock()
+	return p.requests == 0 && p.active == 0
+}
+
+// Index implements pq.Elem.
+func (p *activePartner) Index() int {
+	return p.index
+}
+
+// SetIndex implements pq.Elem.
+func (p *activePartner) SetIndex(i int) {
+	p.index = i
+}

--- a/decision/peer_request_queue_test.go
+++ b/decision/peer_request_queue_test.go
@@ -1,0 +1,162 @@
+package decision
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ipfs/go-bitswap/wantlist"
+	cid "github.com/ipfs/go-cid"
+	u "github.com/ipfs/go-ipfs-util"
+	testutil "github.com/libp2p/go-libp2p-core/test"
+)
+
+func TestPushPop(t *testing.T) {
+	prq := newPRQ()
+	partner := testutil.RandPeerIDFatal(t)
+	alphabet := strings.Split("abcdefghijklmnopqrstuvwxyz", "")
+	vowels := strings.Split("aeiou", "")
+	consonants := func() []string {
+		var out []string
+		for _, letter := range alphabet {
+			skip := false
+			for _, vowel := range vowels {
+				if letter == vowel {
+					skip = true
+				}
+			}
+			if !skip {
+				out = append(out, letter)
+			}
+		}
+		return out
+	}()
+	sort.Strings(alphabet)
+	sort.Strings(vowels)
+	sort.Strings(consonants)
+
+	// add a bunch of blocks. cancel some. drain the queue. the queue should only have the kept entries
+
+	for _, index := range rand.Perm(len(alphabet)) { // add blocks for all letters
+		letter := alphabet[index]
+		t.Log(partner.String())
+
+		c := cid.NewCidV0(u.Hash([]byte(letter)))
+		prq.Push(partner, wantlist.Entry{Cid: c, Priority: math.MaxInt32 - index})
+	}
+	for _, consonant := range consonants {
+		c := cid.NewCidV0(u.Hash([]byte(consonant)))
+		prq.Remove(c, partner)
+	}
+
+	prq.fullThaw()
+
+	var out []string
+	for {
+		received := prq.Pop()
+		if received == nil {
+			break
+		}
+
+		for _, entry := range received.Entries {
+			out = append(out, entry.Cid.String())
+		}
+	}
+
+	// Entries popped should already be in correct order
+	for i, expected := range vowels {
+		exp := cid.NewCidV0(u.Hash([]byte(expected))).String()
+		if out[i] != exp {
+			t.Fatal("received", out[i], "expected", expected)
+		}
+	}
+}
+
+// This test checks that peers wont starve out other peers
+func TestPeerRepeats(t *testing.T) {
+	prq := newPRQ()
+	a := testutil.RandPeerIDFatal(t)
+	b := testutil.RandPeerIDFatal(t)
+	c := testutil.RandPeerIDFatal(t)
+	d := testutil.RandPeerIDFatal(t)
+
+	// Have each push some blocks
+
+	for i := 0; i < 5; i++ {
+		elcid := cid.NewCidV0(u.Hash([]byte(fmt.Sprint(i))))
+		prq.Push(a, wantlist.Entry{Cid: elcid})
+		prq.Push(b, wantlist.Entry{Cid: elcid})
+		prq.Push(c, wantlist.Entry{Cid: elcid})
+		prq.Push(d, wantlist.Entry{Cid: elcid})
+	}
+
+	// now, pop off four entries, there should be one from each
+	var targets []string
+	var tasks []*peerRequestTask
+	for i := 0; i < 4; i++ {
+		t := prq.Pop()
+		targets = append(targets, t.Target.Pretty())
+		tasks = append(tasks, t)
+	}
+
+	expected := []string{a.Pretty(), b.Pretty(), c.Pretty(), d.Pretty()}
+	sort.Strings(expected)
+	sort.Strings(targets)
+
+	t.Log(targets)
+	t.Log(expected)
+	for i, s := range targets {
+		if expected[i] != s {
+			t.Fatal("unexpected peer", s, expected[i])
+		}
+	}
+
+	// Now, if one of the tasks gets finished, the next task off the queue should
+	// be for the same peer
+	for blockI := 0; blockI < 4; blockI++ {
+		for i := 0; i < 4; i++ {
+			// its okay to mark the same task done multiple times here (JUST FOR TESTING)
+			tasks[i].Done(tasks[i].Entries)
+
+			ntask := prq.Pop()
+			if ntask.Target != tasks[i].Target {
+				t.Fatal("Expected task from peer with lowest active count")
+			}
+		}
+	}
+}
+
+func TestCleaningUpQueues(t *testing.T) {
+	partner := testutil.RandPeerIDFatal(t)
+	var entries []wantlist.Entry
+	for i := 0; i < 5; i++ {
+		entries = append(entries, wantlist.Entry{Cid: cid.NewCidV0(u.Hash([]byte(fmt.Sprint(i))))})
+	}
+
+	prq := newPRQ()
+
+	// push a block, pop a block, complete everything, should be removed
+	prq.Push(partner, entries...)
+	task := prq.Pop()
+	task.Done(task.Entries)
+	task = prq.Pop()
+
+	if task != nil || len(prq.partners) > 0 || prq.pQueue.Len() > 0 {
+		t.Fatal("Partner should have been removed because it's idle")
+	}
+
+	// push a block, remove each of its entries, should be removed
+	prq.Push(partner, entries...)
+	for _, entry := range entries {
+		prq.Remove(entry.Cid, partner)
+	}
+	task = prq.Pop()
+
+	if task != nil || len(prq.partners) > 0 || prq.pQueue.Len() > 0 {
+		t.Fatal("Partner should have been removed because it's idle")
+	}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-ipfs-delay v0.0.1
 	github.com/ipfs/go-ipfs-exchange-interface v0.0.1
+	github.com/ipfs/go-ipfs-pq v0.0.1
 	github.com/ipfs/go-ipfs-routing v0.1.0
 	github.com/ipfs/go-ipfs-util v0.0.1
 	github.com/ipfs/go-log v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,8 @@ github.com/libp2p/go-stream-muxer-multistream v0.2.0 h1:714bRJ4Zy9mdhyTLJ+ZKiROm
 github.com/libp2p/go-stream-muxer-multistream v0.2.0/go.mod h1:j9eyPol/LLRqT+GPLSxvimPhNph4sfYfMoDPd7HkzIc=
 github.com/libp2p/go-tcp-transport v0.1.0 h1:IGhowvEqyMFknOar4FWCKSWE0zL36UFKQtiRQD60/8o=
 github.com/libp2p/go-tcp-transport v0.1.0/go.mod h1:oJ8I5VXryj493DEJ7OsBieu8fcg2nHGctwtInJVpipc=
+github.com/libp2p/go-testutil v0.1.0 h1:4QhjaWGO89udplblLVpgGDOQjzFlRavZOjuEnz2rLMc=
+github.com/libp2p/go-testutil v0.1.0/go.mod h1:81b2n5HypcVyrCg/MJx4Wgfp/VHojytjVe/gLzZ2Ehc=
 github.com/libp2p/go-ws-transport v0.1.0 h1:F+0OvvdmPTDsVc4AjPHjV7L7Pk1B7D5QwtDcKE2oag4=
 github.com/libp2p/go-ws-transport v0.1.0/go.mod h1:rjw1MG1LU9YDC6gzmwObkPd/Sqwhw7yT74kj3raBFuo=
 github.com/libp2p/go-yamux v1.2.2 h1:s6J6o7+ajoQMjHe7BEnq+EynOj5D2EoG8CuQgL3F2vg=


### PR DESCRIPTION
Peer task queue extracted package is causing the add/cat performance regression. 

Have yet to investigate why. However, for the time being, this removes it.