### PR TITLE
Feat: Track Session Peer Latency More Accurately

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -333,9 +333,8 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 			defer wg.Done()
 
 			bs.updateReceiveCounters(b)
-			bs.sm.UpdateReceiveCounters(b)
+			bs.sm.UpdateReceiveCounters(p, b)
 			log.Debugf("[recv] block; cid=%s, peer=%s", b.Cid(), p)
-
 			// skip received blocks that are not in the wantlist
 			if !bs.wm.IsWanted(b.Cid()) {
 				log.Debugf("[recv] block not in wantlist; cid=%s, peer=%s", b.Cid(), p)

--- a/session/session.go
+++ b/session/session.go
@@ -147,9 +147,9 @@ func (s *Session) ReceiveBlockFrom(from peer.ID, blk blocks.Block) {
 
 // UpdateReceiveCounters updates receive counters for a block,
 // which may be a duplicate and adjusts the split factor based on that.
-func (s *Session) UpdateReceiveCounters(blk blocks.Block) {
+func (s *Session) UpdateReceiveCounters(from peer.ID, blk blocks.Block) {
 	select {
-	case s.incoming <- blkRecv{from: "", blk: blk, counterMessage: true}:
+	case s.incoming <- blkRecv{from: from, blk: blk, counterMessage: true}:
 	case <-s.ctx.Done():
 	}
 }
@@ -308,7 +308,6 @@ func (s *Session) handleCancel(keys []cid.Cid) {
 }
 
 func (s *Session) handleIdleTick(ctx context.Context) {
-
 	live := make([]cid.Cid, 0, len(s.liveWants))
 	now := time.Now()
 	for c := range s.liveWants {
@@ -415,6 +414,9 @@ func (s *Session) updateReceiveCounters(ctx context.Context, blk blkRecv) {
 	ks := blk.blk.Cid()
 	if s.pastWants.Has(ks) {
 		s.srs.RecordDuplicateBlock()
+		if blk.from != "" {
+			s.pm.RecordPeerResponse(blk.from, ks)
+		}
 	}
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -15,7 +15,6 @@ import (
 	logging "github.com/ipfs/go-log"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	loggables "github.com/libp2p/go-libp2p-loggables"
-
 )
 
 const (
@@ -37,6 +36,7 @@ type PeerManager interface {
 	GetOptimizedPeers() []bssd.OptimizedPeer
 	RecordPeerRequests([]peer.ID, []cid.Cid)
 	RecordPeerResponse(peer.ID, cid.Cid)
+	RecordCancel(cid.Cid)
 }
 
 // RequestSplitter provides an interface for splitting
@@ -141,8 +141,8 @@ func (s *Session) ReceiveBlockFrom(from peer.ID, blk blocks.Block) {
 	case <-s.ctx.Done():
 	}
 	ks := []cid.Cid{blk.Cid()}
+	s.pm.RecordCancel(blk.Cid())
 	s.wm.CancelWants(s.ctx, ks, nil, s.id)
-
 }
 
 // UpdateReceiveCounters updates receive counters for a block,

--- a/session/session.go
+++ b/session/session.go
@@ -8,6 +8,7 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	bsgetter "github.com/ipfs/go-bitswap/getter"
 	notifications "github.com/ipfs/go-bitswap/notifications"
+	bssd "github.com/ipfs/go-bitswap/sessiondata"
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 	delay "github.com/ipfs/go-ipfs-delay"
@@ -15,7 +16,6 @@ import (
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	loggables "github.com/libp2p/go-libp2p-loggables"
 
-	bssrs "github.com/ipfs/go-bitswap/sessionrequestsplitter"
 )
 
 const (
@@ -34,7 +34,7 @@ type WantManager interface {
 // requesting more when neccesary.
 type PeerManager interface {
 	FindMorePeers(context.Context, cid.Cid)
-	GetOptimizedPeers() []peer.ID
+	GetOptimizedPeers() []bssd.OptimizedPeer
 	RecordPeerRequests([]peer.ID, []cid.Cid)
 	RecordPeerResponse(peer.ID, cid.Cid)
 }
@@ -42,7 +42,7 @@ type PeerManager interface {
 // RequestSplitter provides an interface for splitting
 // a request for Cids up among peers.
 type RequestSplitter interface {
-	SplitRequest([]peer.ID, []cid.Cid) []*bssrs.PartialRequest
+	SplitRequest([]bssd.OptimizedPeer, []cid.Cid) []bssd.PartialRequest
 	RecordDuplicateBlock()
 	RecordUniqueBlock()
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -68,6 +68,7 @@ func (fpm *fakePeerManager) RecordPeerResponse(p peer.ID, c cid.Cid) {
 	fpm.peers = append(fpm.peers, p)
 	fpm.lk.Unlock()
 }
+func (fpm *fakePeerManager) RecordCancel(c cid.Cid) {}
 
 type fakeRequestSplitter struct {
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	bssrs "github.com/ipfs/go-bitswap/sessionrequestsplitter"
+	bssd "github.com/ipfs/go-bitswap/sessiondata"
 	"github.com/ipfs/go-bitswap/testutil"
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
@@ -52,10 +52,14 @@ func (fpm *fakePeerManager) FindMorePeers(ctx context.Context, k cid.Cid) {
 	}
 }
 
-func (fpm *fakePeerManager) GetOptimizedPeers() []peer.ID {
+func (fpm *fakePeerManager) GetOptimizedPeers() []bssd.OptimizedPeer {
 	fpm.lk.Lock()
 	defer fpm.lk.Unlock()
-	return fpm.peers
+	optimizedPeers := make([]bssd.OptimizedPeer, 0, len(fpm.peers))
+	for _, peer := range fpm.peers {
+		optimizedPeers = append(optimizedPeers, bssd.OptimizedPeer{Peer: peer, OptimizationRating: 1.0})
+	}
+	return optimizedPeers
 }
 
 func (fpm *fakePeerManager) RecordPeerRequests([]peer.ID, []cid.Cid) {}
@@ -68,8 +72,12 @@ func (fpm *fakePeerManager) RecordPeerResponse(p peer.ID, c cid.Cid) {
 type fakeRequestSplitter struct {
 }
 
-func (frs *fakeRequestSplitter) SplitRequest(peers []peer.ID, keys []cid.Cid) []*bssrs.PartialRequest {
-	return []*bssrs.PartialRequest{&bssrs.PartialRequest{Peers: peers, Keys: keys}}
+func (frs *fakeRequestSplitter) SplitRequest(optimizedPeers []bssd.OptimizedPeer, keys []cid.Cid) []bssd.PartialRequest {
+	peers := make([]peer.ID, len(optimizedPeers))
+	for i, optimizedPeer := range optimizedPeers {
+		peers[i] = optimizedPeer.Peer
+	}
+	return []bssd.PartialRequest{bssd.PartialRequest{Peers: peers, Keys: keys}}
 }
 
 func (frs *fakeRequestSplitter) RecordDuplicateBlock() {}

--- a/sessiondata/sessiondata.go
+++ b/sessiondata/sessiondata.go
@@ -1,0 +1,18 @@
+package sessiondata
+
+import (
+	cid "github.com/ipfs/go-cid"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+)
+
+// OptimizedPeer describes a peer and its level of optimization from 0 to 1.
+type OptimizedPeer struct {
+	Peer               peer.ID
+	OptimizationRating float64
+}
+
+// PartialRequest is represents one slice of an over request split among peers
+type PartialRequest struct {
+	Peers []peer.ID
+	Keys  []cid.Cid
+}

--- a/sessionmanager/sessionmanager.go
+++ b/sessionmanager/sessionmanager.go
@@ -19,7 +19,7 @@ type Session interface {
 	exchange.Fetcher
 	InterestedIn(cid.Cid) bool
 	ReceiveBlockFrom(peer.ID, blocks.Block)
-	UpdateReceiveCounters(blocks.Block)
+	UpdateReceiveCounters(peer.ID, blocks.Block)
 }
 
 type sesTrk struct {
@@ -128,11 +128,11 @@ func (sm *SessionManager) ReceiveBlockFrom(from peer.ID, blk blocks.Block) {
 
 // UpdateReceiveCounters records the fact that a block was received, allowing
 // sessions to track duplicates
-func (sm *SessionManager) UpdateReceiveCounters(blk blocks.Block) {
+func (sm *SessionManager) UpdateReceiveCounters(from peer.ID, blk blocks.Block) {
 	sm.sessLk.Lock()
 	defer sm.sessLk.Unlock()
 
 	for _, s := range sm.sessions {
-		s.session.UpdateReceiveCounters(blk)
+		s.session.UpdateReceiveCounters(from, blk)
 	}
 }

--- a/sessionmanager/sessionmanager_test.go
+++ b/sessionmanager/sessionmanager_test.go
@@ -30,9 +30,9 @@ func (*fakeSession) GetBlock(context.Context, cid.Cid) (blocks.Block, error) {
 func (*fakeSession) GetBlocks(context.Context, []cid.Cid) (<-chan blocks.Block, error) {
 	return nil, nil
 }
-func (fs *fakeSession) InterestedIn(cid.Cid) bool              { return fs.interested }
-func (fs *fakeSession) ReceiveBlockFrom(peer.ID, blocks.Block) { fs.receivedBlock = true }
-func (fs *fakeSession) UpdateReceiveCounters(blocks.Block)     { fs.updateReceiveCounters = true }
+func (fs *fakeSession) InterestedIn(cid.Cid) bool                   { return fs.interested }
+func (fs *fakeSession) ReceiveBlockFrom(peer.ID, blocks.Block)      { fs.receivedBlock = true }
+func (fs *fakeSession) UpdateReceiveCounters(peer.ID, blocks.Block) { fs.updateReceiveCounters = true }
 
 type fakePeerManager struct {
 	id uint64

--- a/sessionmanager/sessionmanager_test.go
+++ b/sessionmanager/sessionmanager_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	bssrs "github.com/ipfs/go-bitswap/sessionrequestsplitter"
 	delay "github.com/ipfs/go-ipfs-delay"
 
 	bssession "github.com/ipfs/go-bitswap/session"
+	bssd "github.com/ipfs/go-bitswap/sessiondata"
 
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
@@ -39,14 +39,14 @@ type fakePeerManager struct {
 }
 
 func (*fakePeerManager) FindMorePeers(context.Context, cid.Cid)  {}
-func (*fakePeerManager) GetOptimizedPeers() []peer.ID            { return nil }
+func (*fakePeerManager) GetOptimizedPeers() []bssd.OptimizedPeer { return nil }
 func (*fakePeerManager) RecordPeerRequests([]peer.ID, []cid.Cid) {}
 func (*fakePeerManager) RecordPeerResponse(peer.ID, cid.Cid)     {}
 
 type fakeRequestSplitter struct {
 }
 
-func (frs *fakeRequestSplitter) SplitRequest(peers []peer.ID, keys []cid.Cid) []*bssrs.PartialRequest {
+func (frs *fakeRequestSplitter) SplitRequest(optimizedPeers []bssd.OptimizedPeer, keys []cid.Cid) []bssd.PartialRequest {
 	return nil
 }
 func (frs *fakeRequestSplitter) RecordDuplicateBlock() {}

--- a/sessionmanager/sessionmanager_test.go
+++ b/sessionmanager/sessionmanager_test.go
@@ -42,6 +42,7 @@ func (*fakePeerManager) FindMorePeers(context.Context, cid.Cid)  {}
 func (*fakePeerManager) GetOptimizedPeers() []bssd.OptimizedPeer { return nil }
 func (*fakePeerManager) RecordPeerRequests([]peer.ID, []cid.Cid) {}
 func (*fakePeerManager) RecordPeerResponse(peer.ID, cid.Cid)     {}
+func (*fakePeerManager) RecordCancel(c cid.Cid)                  {}
 
 type fakeRequestSplitter struct {
 }

--- a/sessionpeermanager/latencytracker.go
+++ b/sessionpeermanager/latencytracker.go
@@ -1,0 +1,65 @@
+package sessionpeermanager
+
+import (
+	"time"
+
+	"github.com/ipfs/go-cid"
+)
+
+const (
+	timeoutDuration = 5 * time.Second
+)
+
+type requestData struct {
+	startedAt   time.Time
+	timeoutFunc *time.Timer
+}
+
+type latencyTracker struct {
+	requests map[cid.Cid]*requestData
+}
+
+func newLatencyTracker() *latencyTracker {
+	return &latencyTracker{requests: make(map[cid.Cid]*requestData)}
+}
+
+type afterTimeoutFunc func(cid.Cid)
+
+func (lt *latencyTracker) SetupRequests(keys []cid.Cid, afterTimeout afterTimeoutFunc) {
+	startedAt := time.Now()
+	for _, k := range keys {
+		if _, ok := lt.requests[k]; !ok {
+			lt.requests[k] = &requestData{startedAt, time.AfterFunc(timeoutDuration, makeAfterTimeout(afterTimeout, k))}
+		}
+	}
+}
+
+func makeAfterTimeout(afterTimeout afterTimeoutFunc, k cid.Cid) func() {
+	return func() { afterTimeout(k) }
+}
+
+func (lt *latencyTracker) CheckDuration(key cid.Cid) (time.Duration, bool) {
+	request, ok := lt.requests[key]
+	var latency time.Duration
+	if ok {
+		latency = time.Now().Sub(request.startedAt)
+	}
+	return latency, ok
+}
+
+func (lt *latencyTracker) RecordResponse(key cid.Cid) (time.Duration, bool) {
+	request, ok := lt.requests[key]
+	var latency time.Duration
+	if ok {
+		latency = time.Now().Sub(request.startedAt)
+		request.timeoutFunc.Stop()
+		delete(lt.requests, key)
+	}
+	return latency, ok
+}
+
+func (lt *latencyTracker) Shutdown() {
+	for _, request := range lt.requests {
+		request.timeoutFunc.Stop()
+	}
+}

--- a/sessionpeermanager/peerdata.go
+++ b/sessionpeermanager/peerdata.go
@@ -1,0 +1,41 @@
+package sessionpeermanager
+
+import (
+	"time"
+
+	"github.com/ipfs/go-cid"
+)
+
+const (
+	newLatencyWeight = 0.5
+)
+
+type peerData struct {
+	hasLatency bool
+	latency    time.Duration
+	lt         *latencyTracker
+}
+
+func newPeerData() *peerData {
+	return &peerData{
+		hasLatency: false,
+		lt:         newLatencyTracker(),
+		latency:    0,
+	}
+}
+
+func (pd *peerData) AdjustLatency(k cid.Cid, hasFallbackLatency bool, fallbackLatency time.Duration) {
+
+	latency, hasLatency := pd.lt.RecordResponse(k)
+	if !hasLatency {
+		latency, hasLatency = fallbackLatency, hasFallbackLatency
+	}
+	if hasLatency {
+		if pd.hasLatency {
+			pd.latency = time.Duration(float64(pd.latency)*(1.0-newLatencyWeight) + float64(latency)*newLatencyWeight)
+		} else {
+			pd.latency = latency
+			pd.hasLatency = true
+		}
+	}
+}

--- a/sessionpeermanager/peerdata.go
+++ b/sessionpeermanager/peerdata.go
@@ -25,8 +25,8 @@ func newPeerData() *peerData {
 }
 
 func (pd *peerData) AdjustLatency(k cid.Cid, hasFallbackLatency bool, fallbackLatency time.Duration) {
-
-	latency, hasLatency := pd.lt.RecordResponse(k)
+	latency, hasLatency := pd.lt.CheckDuration(k)
+	pd.lt.RemoveRequest(k)
 	if !hasLatency {
 		latency, hasLatency = fallbackLatency, hasFallbackLatency
 	}

--- a/sessionpeermanager/sessionpeermanager_test.go
+++ b/sessionpeermanager/sessionpeermanager_test.go
@@ -241,6 +241,115 @@ func TestOrderingPeers(t *testing.T) {
 	}
 }
 
+func TestTimeoutsAndCancels(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	peers := testutil.GeneratePeers(3)
+	completed := make(chan struct{})
+	fpt := &fakePeerTagger{}
+	fppf := &fakePeerProviderFinder{peers, completed}
+	c := testutil.GenerateCids(1)
+	id := testutil.GenerateSessionID()
+	sessionPeerManager := New(ctx, id, fpt, fppf)
+
+	// add all peers to session
+	sessionPeerManager.FindMorePeers(ctx, c[0])
+	select {
+	case <-completed:
+	case <-ctx.Done():
+		t.Fatal("Did not finish finding providers")
+	}
+	time.Sleep(2 * time.Millisecond)
+
+	sessionPeerManager.SetTimeoutDuration(20 * time.Millisecond)
+
+	// record broadcast
+	sessionPeerManager.RecordPeerRequests(nil, c)
+
+	// record receives
+	peer1 := peers[0]
+	peer2 := peers[1]
+	peer3 := peers[2]
+	time.Sleep(1 * time.Millisecond)
+	sessionPeerManager.RecordPeerResponse(peer1, c[0])
+	time.Sleep(2 * time.Millisecond)
+	sessionPeerManager.RecordPeerResponse(peer2, c[0])
+	time.Sleep(40 * time.Millisecond)
+	sessionPeerManager.RecordPeerResponse(peer3, c[0])
+
+	sessionPeers := sessionPeerManager.GetOptimizedPeers()
+
+	// should prioritize peers which are fastest
+	if (sessionPeers[0].Peer != peer1) || (sessionPeers[1].Peer != peer2) || (sessionPeers[2].Peer != peer3) {
+		t.Fatal("Did not prioritize peers that received blocks")
+	}
+
+	// should give first peer rating of 1
+	if sessionPeers[0].OptimizationRating < 1.0 {
+		t.Fatal("Did not assign rating to best peer correctly")
+	}
+
+	// should give other optimized peers ratings between 0 & 1
+	if (sessionPeers[1].OptimizationRating >= 1.0) || (sessionPeers[1].OptimizationRating <= 0.0) {
+		t.Fatal("Did not assign rating to other optimized peers correctly")
+	}
+
+	// should not record a response for a broadcast return that arrived AFTER the timeout period
+	// leaving peer unoptimized
+	if sessionPeers[2].OptimizationRating != 0 {
+		t.Fatal("should not have recorded broadcast response for peer that arrived after timeout period")
+	}
+
+	// now we make a targeted request, which SHOULD affect peer
+	// rating if it times out
+	c2 := testutil.GenerateCids(1)
+
+	// Request again
+	sessionPeerManager.RecordPeerRequests([]peer.ID{peer2}, c2)
+	// wait for a timeout
+	time.Sleep(40 * time.Millisecond)
+
+	// call again
+	nextSessionPeers := sessionPeerManager.GetOptimizedPeers()
+	if sessionPeers[1].OptimizationRating <= nextSessionPeers[1].OptimizationRating {
+		t.Fatal("Timeout should have affected optimization rating but did not")
+	}
+
+	// now we make a targeted request, but later cancel it
+	// timing out should not affect rating
+	c3 := testutil.GenerateCids(1)
+
+	// Request again
+	sessionPeerManager.RecordPeerRequests([]peer.ID{peer2}, c3)
+	sessionPeerManager.RecordCancel(c3[0])
+	// wait for a timeout
+	time.Sleep(40 * time.Millisecond)
+
+	// call again
+	thirdSessionPeers := sessionPeerManager.GetOptimizedPeers()
+	if nextSessionPeers[1].OptimizationRating != thirdSessionPeers[1].OptimizationRating {
+		t.Fatal("Timeout should not have affected optimization rating but did")
+	}
+
+	// if we make a targeted request that is then cancelled, but we still
+	// receive the block before the timeout, it's worth recording and affecting latency
+
+	c4 := testutil.GenerateCids(1)
+
+	// Request again
+	sessionPeerManager.RecordPeerRequests([]peer.ID{peer2}, c4)
+	sessionPeerManager.RecordCancel(c4[0])
+	time.Sleep(2 * time.Millisecond)
+	sessionPeerManager.RecordPeerResponse(peer2, c4[0])
+
+	// call again
+	fourthSessionPeers := sessionPeerManager.GetOptimizedPeers()
+	if thirdSessionPeers[1].OptimizationRating >= fourthSessionPeers[1].OptimizationRating {
+		t.Fatal("Timeout should have affected optimization rating but did not")
+	}
+}
+
 func TestUntaggingPeers(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)

--- a/sessionrequestsplitter/sessionrequestsplitter.go
+++ b/sessionrequestsplitter/sessionrequestsplitter.go
@@ -3,6 +3,8 @@ package sessionrequestsplitter
 import (
 	"context"
 
+	bssd "github.com/ipfs/go-bitswap/sessiondata"
+
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
@@ -14,12 +16,6 @@ const (
 	minDuplesToTryLessSplits = 0.2
 	initialSplit             = 2
 )
-
-// PartialRequest is represents one slice of an over request split among peers
-type PartialRequest struct {
-	Peers []peer.ID
-	Keys  []cid.Cid
-}
 
 type srsMessage interface {
 	handle(srs *SessionRequestSplitter)
@@ -50,11 +46,11 @@ func New(ctx context.Context) *SessionRequestSplitter {
 
 // SplitRequest splits a request for the given cids one or more times among the
 // given peers.
-func (srs *SessionRequestSplitter) SplitRequest(peers []peer.ID, ks []cid.Cid) []*PartialRequest {
-	resp := make(chan []*PartialRequest, 1)
+func (srs *SessionRequestSplitter) SplitRequest(optimizedPeers []bssd.OptimizedPeer, ks []cid.Cid) []bssd.PartialRequest {
+	resp := make(chan []bssd.PartialRequest, 1)
 
 	select {
-	case srs.messages <- &splitRequestMessage{peers, ks, resp}:
+	case srs.messages <- &splitRequestMessage{optimizedPeers, ks, resp}:
 	case <-srs.ctx.Done():
 		return nil
 	}
@@ -101,14 +97,18 @@ func (srs *SessionRequestSplitter) duplicateRatio() float64 {
 }
 
 type splitRequestMessage struct {
-	peers []peer.ID
-	ks    []cid.Cid
-	resp  chan []*PartialRequest
+	optimizedPeers []bssd.OptimizedPeer
+	ks             []cid.Cid
+	resp           chan []bssd.PartialRequest
 }
 
 func (s *splitRequestMessage) handle(srs *SessionRequestSplitter) {
 	split := srs.split
-	peers := s.peers
+	// first iteration ignore optimization ratings
+	peers := make([]peer.ID, len(s.optimizedPeers))
+	for i, optimizedPeer := range s.optimizedPeers {
+		peers[i] = optimizedPeer.Peer
+	}
 	ks := s.ks
 	if len(peers) < split {
 		split = len(peers)
@@ -118,9 +118,9 @@ func (s *splitRequestMessage) handle(srs *SessionRequestSplitter) {
 		split = len(ks)
 	}
 	keySplits := splitKeys(ks, split)
-	splitRequests := make([]*PartialRequest, len(keySplits))
-	for i := range splitRequests {
-		splitRequests[i] = &PartialRequest{peerSplits[i], keySplits[i]}
+	splitRequests := make([]bssd.PartialRequest, 0, len(keySplits))
+	for i, keySplit := range keySplits {
+		splitRequests = append(splitRequests, bssd.PartialRequest{Peers: peerSplits[i], Keys: keySplit})
 	}
 	s.resp <- splitRequests
 }

--- a/sessionrequestsplitter/sessionrequestsplitter_test.go
+++ b/sessionrequestsplitter/sessionrequestsplitter_test.go
@@ -7,14 +7,16 @@ import (
 	"github.com/ipfs/go-bitswap/testutil"
 )
 
+func quadEaseOut(t float64) float64 { return t * t }
+
 func TestSplittingRequests(t *testing.T) {
 	ctx := context.Background()
-	peers := testutil.GeneratePeers(10)
+	optimizedPeers := testutil.GenerateOptimizedPeers(10, 5, quadEaseOut)
 	keys := testutil.GenerateCids(6)
 
 	srs := New(ctx)
 
-	partialRequests := srs.SplitRequest(peers, keys)
+	partialRequests := srs.SplitRequest(optimizedPeers, keys)
 	if len(partialRequests) != 2 {
 		t.Fatal("Did not generate right number of partial requests")
 	}
@@ -27,12 +29,12 @@ func TestSplittingRequests(t *testing.T) {
 
 func TestSplittingRequestsTooFewKeys(t *testing.T) {
 	ctx := context.Background()
-	peers := testutil.GeneratePeers(10)
+	optimizedPeers := testutil.GenerateOptimizedPeers(10, 5, quadEaseOut)
 	keys := testutil.GenerateCids(1)
 
 	srs := New(ctx)
 
-	partialRequests := srs.SplitRequest(peers, keys)
+	partialRequests := srs.SplitRequest(optimizedPeers, keys)
 	if len(partialRequests) != 1 {
 		t.Fatal("Should only generate as many requests as keys")
 	}
@@ -45,12 +47,12 @@ func TestSplittingRequestsTooFewKeys(t *testing.T) {
 
 func TestSplittingRequestsTooFewPeers(t *testing.T) {
 	ctx := context.Background()
-	peers := testutil.GeneratePeers(1)
+	optimizedPeers := testutil.GenerateOptimizedPeers(1, 1, quadEaseOut)
 	keys := testutil.GenerateCids(6)
 
 	srs := New(ctx)
 
-	partialRequests := srs.SplitRequest(peers, keys)
+	partialRequests := srs.SplitRequest(optimizedPeers, keys)
 	if len(partialRequests) != 1 {
 		t.Fatal("Should only generate as many requests as peers")
 	}
@@ -63,7 +65,7 @@ func TestSplittingRequestsTooFewPeers(t *testing.T) {
 
 func TestSplittingRequestsIncreasingSplitDueToDupes(t *testing.T) {
 	ctx := context.Background()
-	peers := testutil.GeneratePeers(maxSplit)
+	optimizedPeers := testutil.GenerateOptimizedPeers(maxSplit, maxSplit, quadEaseOut)
 	keys := testutil.GenerateCids(maxSplit)
 
 	srs := New(ctx)
@@ -72,7 +74,7 @@ func TestSplittingRequestsIncreasingSplitDueToDupes(t *testing.T) {
 		srs.RecordDuplicateBlock()
 	}
 
-	partialRequests := srs.SplitRequest(peers, keys)
+	partialRequests := srs.SplitRequest(optimizedPeers, keys)
 	if len(partialRequests) != maxSplit {
 		t.Fatal("Did not adjust split up as duplicates came in")
 	}
@@ -80,7 +82,7 @@ func TestSplittingRequestsIncreasingSplitDueToDupes(t *testing.T) {
 
 func TestSplittingRequestsDecreasingSplitDueToNoDupes(t *testing.T) {
 	ctx := context.Background()
-	peers := testutil.GeneratePeers(maxSplit)
+	optimizedPeers := testutil.GenerateOptimizedPeers(maxSplit, maxSplit, quadEaseOut)
 	keys := testutil.GenerateCids(maxSplit)
 
 	srs := New(ctx)
@@ -89,7 +91,7 @@ func TestSplittingRequestsDecreasingSplitDueToNoDupes(t *testing.T) {
 		srs.RecordUniqueBlock()
 	}
 
-	partialRequests := srs.SplitRequest(peers, keys)
+	partialRequests := srs.SplitRequest(optimizedPeers, keys)
 	if len(partialRequests) != 1 {
 		t.Fatal("Did not adjust split down as unique blocks came in")
 	}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 
 	bsmsg "github.com/ipfs/go-bitswap/message"
+	bssd "github.com/ipfs/go-bitswap/sessiondata"
 	"github.com/ipfs/go-bitswap/wantlist"
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
@@ -74,6 +75,24 @@ func GeneratePeers(n int) []peer.ID {
 		peerIds = append(peerIds, p)
 	}
 	return peerIds
+}
+
+// GenerateOptimizedPeers creates n peer ids,
+// with optimization fall off up to optCount, curveFunc to scale it
+func GenerateOptimizedPeers(n int, optCount int, curveFunc func(float64) float64) []bssd.OptimizedPeer {
+	peers := GeneratePeers(n)
+	optimizedPeers := make([]bssd.OptimizedPeer, 0, n)
+	for i, peer := range peers {
+		var optimizationRating float64
+		if i <= optCount {
+			optimizationRating = 1.0 - float64(i)/float64(optCount)
+		} else {
+			optimizationRating = 0.0
+		}
+		optimizationRating = curveFunc(optimizationRating)
+		optimizedPeers = append(optimizedPeers, bssd.OptimizedPeer{Peer: peer, OptimizationRating: optimizationRating})
+	}
+	return optimizedPeers
 }
 
 var nextSession uint64


### PR DESCRIPTION
# Goals

Track the speeds between session peers more accurately

# Implementation

The current SessionPeerManager uses a very simple algorithm for sorting peers by optimization -- it simply orders them by last block received.

This algorithm attempts to actually track peers length of time to respond to requests, and sort them not only by which is fastest, by provide useful information (and optimization rating from 1-0, with 1 being the fastest peer) about how they relate to each other.

The steps are as follows:
1. For a broadcast request, track all responses (not just first one) until a preset timeout period (5 seconds for now) and use that to establish optimization ratings between peers
2. For targeted requests, individually measure time for each peer requested up to a timeout period. If response is received, track total time. If no response is received, but a cancel was sent (usually cause another peer responded first), ignore. If no response is received before a timeout, and no cancel was sent, record the full timeout period as it's latency.
3. Prioritize latency of last response (0.5 * last response + 0.5 * previous latency rating)

# For Discussion

- Is this too complicated and specific (doesn't feel that way to me -- feels like we should produce the best information possible)
- Is the fall off right (0.5)?
- Is the timeout right (5 seconds)?
- Does the logic around which timeouts matter make sense?