### PR TITLE
Feat: process response message blocks as a batch

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -265,23 +265,24 @@ func (bs *Bitswap) GetBlocks(ctx context.Context, keys []cid.Cid) (<-chan blocks
 // HasBlock announces the existence of a block to this bitswap service. The
 // service will potentially notify its peers.
 func (bs *Bitswap) HasBlock(blk blocks.Block) error {
-	return bs.receiveBlockFrom(blk, "")
+	return bs.receiveBlocksFrom("", []blocks.Block{blk}, []blocks.Block{}, false)
 }
 
 // TODO: Some of this stuff really only needs to be done when adding a block
 // from the user, not when receiving it from the network.
 // In case you run `git blame` on this comment, I'll save you some time: ask
 // @whyrusleeping, I don't know the answers you seek.
-func (bs *Bitswap) receiveBlockFrom(blk blocks.Block, from peer.ID) error {
+func (bs *Bitswap) receiveBlocksFrom(from peer.ID, blks []blocks.Block, dups []blocks.Block, fromNetwork bool) error {
 	select {
 	case <-bs.process.Closing():
 		return errors.New("bitswap is closed")
 	default:
 	}
 
-	err := bs.blockstore.Put(blk)
+	// Put blocks into blockstore
+	err := bs.blockstore.PutMany(blks)
 	if err != nil {
-		log.Errorf("Error writing block to datastore: %s", err)
+		log.Errorf("Error writing %d blocks to datastore: %s", len(blks), err)
 		return err
 	}
 
@@ -291,18 +292,24 @@ func (bs *Bitswap) receiveBlockFrom(blk blocks.Block, from peer.ID) error {
 	// to the same node. We should address this soon, but i'm not going to do
 	// it now as it requires more thought and isnt causing immediate problems.
 
-	bs.sm.ReceiveBlockFrom(from, blk)
+	// Send blocks to any sessions that want them
+	bs.sm.ReceiveBlocksFrom(from, blks, dups, fromNetwork)
 
-	bs.engine.AddBlock(blk)
+	// Send blocks to decision engine
+	bs.engine.AddBlocks(blks)
 
+	// If the reprovider is enabled, send blocks to reprovider
 	if bs.provideEnabled {
-		select {
-		case bs.newBlocks <- blk.Cid():
-			// send block off to be reprovided
-		case <-bs.process.Closing():
-			return bs.process.Close()
+		for _, b := range blks {
+			select {
+			case bs.newBlocks <- b.Cid():
+				// send block off to be reprovided
+			case <-bs.process.Closing():
+				return bs.process.Close()
+			}
 		}
 	}
+
 	return nil
 }
 
@@ -325,54 +332,89 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 		return
 	}
 
-	wg := sync.WaitGroup{}
-	for _, block := range iblocks {
-
-		wg.Add(1)
-		go func(b blocks.Block) { // TODO: this probably doesnt need to be a goroutine...
-			defer wg.Done()
-
-			bs.updateReceiveCounters(b)
-			bs.sm.UpdateReceiveCounters(p, b)
-			log.Debugf("[recv] block; cid=%s, peer=%s", b.Cid(), p)
-			// skip received blocks that are not in the wantlist
-			if !bs.wm.IsWanted(b.Cid()) {
-				log.Debugf("[recv] block not in wantlist; cid=%s, peer=%s", b.Cid(), p)
-				return
-			}
-
-			if err := bs.receiveBlockFrom(b, p); err != nil {
-				log.Warningf("ReceiveMessage recvBlockFrom error: %s", err)
-			}
-			log.Event(ctx, "Bitswap.GetBlockRequest.End", b.Cid())
-		}(block)
+	bs.updateReceiveCounters(iblocks)
+	for _, b := range iblocks {
+		log.Debugf("[recv] block; cid=%s, peer=%s", b.Cid(), p)
 	}
-	wg.Wait()
-}
 
-func (bs *Bitswap) updateReceiveCounters(b blocks.Block) {
-	blkLen := len(b.RawData())
-	has, err := bs.blockstore.Has(b.Cid())
+	// Split blocks into wanted blocks vs duplicates
+	wanted := make([]blocks.Block, 0, len(iblocks))
+	var dups []blocks.Block
+	for _, b := range iblocks {
+		if bs.wm.IsWanted(b.Cid()) {
+			wanted = append(wanted, b)
+		} else {
+			dups = append(dups, b)
+			log.Debugf("[recv] block not in wantlist; cid=%s, peer=%s", b.Cid(), p)
+		}
+	}
+
+	// Process blocks
+	err := bs.receiveBlocksFrom(p, wanted, dups, true)
 	if err != nil {
-		log.Infof("blockstore.Has error: %s", err)
+		log.Warningf("ReceiveMessage recvBlockFrom error: %s", err)
 		return
 	}
 
-	bs.allMetric.Observe(float64(blkLen))
-	if has {
-		bs.dupMetric.Observe(float64(blkLen))
+	for _, b := range wanted {
+		log.Event(ctx, "Bitswap.GetBlockRequest.End", b.Cid())
 	}
+}
+
+func (bs *Bitswap) updateReceiveCounters(blocks []blocks.Block) {
+	// Check which blocks are in the datastore
+	blocksHas := bs.blockstoreHas(blocks)
 
 	bs.counterLk.Lock()
 	defer bs.counterLk.Unlock()
-	c := bs.counters
 
-	c.blocksRecvd++
-	c.dataRecvd += uint64(len(b.RawData()))
-	if has {
-		c.dupBlocksRecvd++
-		c.dupDataRecvd += uint64(blkLen)
+	// Do some accounting for each block
+	for i, b := range blocks {
+		has := blocksHas[i]
+		if has == nil {
+			// If there was an error checking the datastore for a block CID,
+			// the error was logged and the CID was not added to the map
+			return
+		}
+
+		blkLen := len(b.RawData())
+		bs.allMetric.Observe(float64(blkLen))
+		if *has {
+			bs.dupMetric.Observe(float64(blkLen))
+		}
+
+		c := bs.counters
+
+		c.blocksRecvd++
+		c.dataRecvd += uint64(blkLen)
+		if *has {
+			c.dupBlocksRecvd++
+			c.dupDataRecvd += uint64(blkLen)
+		}
 	}
+}
+
+func (bs *Bitswap) blockstoreHas(blks []blocks.Block) []*bool {
+	res := make([]*bool, len(blks))
+
+	wg := sync.WaitGroup{}
+	for i, block := range blks {
+		wg.Add(1)
+		go func(i int, b blocks.Block) {
+			defer wg.Done()
+
+			has, err := bs.blockstore.Has(b.Cid())
+			if err != nil {
+				log.Infof("blockstore.Has error: %s", err)
+				return
+			}
+
+			res[i] = &has
+		}(i, block)
+	}
+	wg.Wait()
+
+	return res
 }
 
 // PeerConnected is called by the network interface

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -63,12 +63,12 @@ func (fpm *fakePeerManager) GetOptimizedPeers() []bssd.OptimizedPeer {
 }
 
 func (fpm *fakePeerManager) RecordPeerRequests([]peer.ID, []cid.Cid) {}
-func (fpm *fakePeerManager) RecordPeerResponse(p peer.ID, c cid.Cid) {
+func (fpm *fakePeerManager) RecordPeerResponse(p peer.ID, c []cid.Cid) {
 	fpm.lk.Lock()
 	fpm.peers = append(fpm.peers, p)
 	fpm.lk.Unlock()
 }
-func (fpm *fakePeerManager) RecordCancel(c cid.Cid) {}
+func (fpm *fakePeerManager) RecordCancels(c []cid.Cid) {}
 
 type fakeRequestSplitter struct {
 }
@@ -122,7 +122,7 @@ func TestSessionGetBlocks(t *testing.T) {
 	var newBlockReqs []wantReq
 	var receivedBlocks []blocks.Block
 	for i, p := range peers {
-		session.ReceiveBlockFrom(p, blks[testutil.IndexOf(blks, receivedWantReq.cids[i])])
+		session.ReceiveBlocksFrom(p, []blocks.Block{blks[testutil.IndexOf(blks, receivedWantReq.cids[i])]}, []blocks.Block{}, true)
 		select {
 		case cancelBlock := <-cancelReqs:
 			newCancelReqs = append(newCancelReqs, cancelBlock)
@@ -178,7 +178,7 @@ func TestSessionGetBlocks(t *testing.T) {
 
 	// receive remaining blocks
 	for i, p := range peers {
-		session.ReceiveBlockFrom(p, blks[testutil.IndexOf(blks, newCidsRequested[i])])
+		session.ReceiveBlocksFrom(p, []blocks.Block{blks[testutil.IndexOf(blks, newCidsRequested[i])]}, []blocks.Block{}, true)
 		receivedBlock := <-getBlocksCh
 		receivedBlocks = append(receivedBlocks, receivedBlock)
 		cancelBlock := <-cancelReqs
@@ -230,7 +230,7 @@ func TestSessionFindMorePeers(t *testing.T) {
 	// or there will be no tick set -- time precision on Windows in go is in the
 	// millisecond range
 	p := testutil.GeneratePeers(1)[0]
-	session.ReceiveBlockFrom(p, blks[0])
+	session.ReceiveBlocksFrom(p, []blocks.Block{blks[0]}, []blocks.Block{}, true)
 	select {
 	case <-cancelReqs:
 	case <-ctx.Done():

--- a/sessionmanager/sessionmanager_test.go
+++ b/sessionmanager/sessionmanager_test.go
@@ -9,6 +9,7 @@ import (
 
 	bssession "github.com/ipfs/go-bitswap/session"
 	bssd "github.com/ipfs/go-bitswap/sessiondata"
+	"github.com/ipfs/go-bitswap/testutil"
 
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
@@ -16,7 +17,10 @@ import (
 )
 
 type fakeSession struct {
-	interested            bool
+	interested            []cid.Cid
+	blks                  []blocks.Block
+	dups                  []blocks.Block
+	fromNetwork           bool
 	receivedBlock         bool
 	updateReceiveCounters bool
 	id                    uint64
@@ -30,9 +34,19 @@ func (*fakeSession) GetBlock(context.Context, cid.Cid) (blocks.Block, error) {
 func (*fakeSession) GetBlocks(context.Context, []cid.Cid) (<-chan blocks.Block, error) {
 	return nil, nil
 }
-func (fs *fakeSession) InterestedIn(cid.Cid) bool                   { return fs.interested }
-func (fs *fakeSession) ReceiveBlockFrom(peer.ID, blocks.Block)      { fs.receivedBlock = true }
-func (fs *fakeSession) UpdateReceiveCounters(peer.ID, blocks.Block) { fs.updateReceiveCounters = true }
+func (fs *fakeSession) InterestedIn(c cid.Cid) bool {
+	for _, ic := range fs.interested {
+		if c == ic {
+			return true
+		}
+	}
+	return false
+}
+func (fs *fakeSession) ReceiveBlocksFrom(p peer.ID, blks []blocks.Block, dups []blocks.Block, fromNetwork bool) {
+	fs.blks = append(fs.blks, blks...)
+	fs.dups = append(fs.dups, dups...)
+	fs.fromNetwork = fromNetwork
+}
 
 type fakePeerManager struct {
 	id uint64
@@ -41,8 +55,8 @@ type fakePeerManager struct {
 func (*fakePeerManager) FindMorePeers(context.Context, cid.Cid)  {}
 func (*fakePeerManager) GetOptimizedPeers() []bssd.OptimizedPeer { return nil }
 func (*fakePeerManager) RecordPeerRequests([]peer.ID, []cid.Cid) {}
-func (*fakePeerManager) RecordPeerResponse(peer.ID, cid.Cid)     {}
-func (*fakePeerManager) RecordCancel(c cid.Cid)                  {}
+func (*fakePeerManager) RecordPeerResponse(peer.ID, []cid.Cid)   {}
+func (*fakePeerManager) RecordCancels(c []cid.Cid)               {}
 
 type fakeRequestSplitter struct {
 }
@@ -53,7 +67,7 @@ func (frs *fakeRequestSplitter) SplitRequest(optimizedPeers []bssd.OptimizedPeer
 func (frs *fakeRequestSplitter) RecordDuplicateBlock() {}
 func (frs *fakeRequestSplitter) RecordUniqueBlock()    {}
 
-var nextInterestedIn bool
+var nextInterestedIn []cid.Cid
 
 func sessionFactory(ctx context.Context,
 	id uint64,
@@ -62,11 +76,10 @@ func sessionFactory(ctx context.Context,
 	provSearchDelay time.Duration,
 	rebroadcastDelay delay.D) Session {
 	return &fakeSession{
-		interested:    nextInterestedIn,
-		receivedBlock: false,
-		id:            id,
-		pm:            pm.(*fakePeerManager),
-		srs:           srs.(*fakeRequestSplitter),
+		interested: nextInterestedIn,
+		id:         id,
+		pm:         pm.(*fakePeerManager),
+		srs:        srs.(*fakeRequestSplitter),
 	}
 }
 
@@ -78,6 +91,28 @@ func requestSplitterFactory(ctx context.Context) bssession.RequestSplitter {
 	return &fakeRequestSplitter{}
 }
 
+func cmpSessionCids(s *fakeSession, blks []cid.Cid, dups []cid.Cid) bool {
+	return cmpBlockCids(s.blks, blks) && cmpBlockCids(s.dups, dups)
+}
+
+func cmpBlockCids(blks []blocks.Block, cids []cid.Cid) bool {
+	if len(blks) != len(cids) {
+		return false
+	}
+	for _, b := range blks {
+		has := false
+		for _, c := range cids {
+			if c == b.Cid() {
+				has = true
+			}
+		}
+		if !has {
+			return false
+		}
+	}
+	return true
+}
+
 func TestAddingSessions(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
@@ -87,7 +122,7 @@ func TestAddingSessions(t *testing.T) {
 	p := peer.ID(123)
 	block := blocks.NewBlock([]byte("block"))
 	// we'll be interested in all blocks for this test
-	nextInterestedIn = true
+	nextInterestedIn = []cid.Cid{block.Cid()}
 
 	currentID := sm.GetNextSessionID()
 	firstSession := sm.NewSession(ctx, time.Second, delay.Fixed(time.Minute)).(*fakeSession)
@@ -106,10 +141,10 @@ func TestAddingSessions(t *testing.T) {
 		thirdSession.id != secondSession.id+2 {
 		t.Fatal("session does not have correct id set")
 	}
-	sm.ReceiveBlockFrom(p, block)
-	if !firstSession.receivedBlock ||
-		!secondSession.receivedBlock ||
-		!thirdSession.receivedBlock {
+	sm.ReceiveBlocksFrom(p, []blocks.Block{block}, []blocks.Block{}, true)
+	if len(firstSession.blks) == 0 ||
+		len(secondSession.blks) == 0 ||
+		len(thirdSession.blks) == 0 {
 		t.Fatal("should have received blocks but didn't")
 	}
 }
@@ -121,20 +156,31 @@ func TestReceivingBlocksWhenNotInterested(t *testing.T) {
 	sm := New(ctx, sessionFactory, peerManagerFactory, requestSplitterFactory)
 
 	p := peer.ID(123)
-	block := blocks.NewBlock([]byte("block"))
-	// we'll be interested in all blocks for this test
-	nextInterestedIn = false
+	blks := testutil.GenerateBlocksOfSize(3, 1024)
+	var cids []cid.Cid
+	for _, b := range blks {
+		cids = append(cids, b.Cid())
+	}
+
+	nextInterestedIn = []cid.Cid{cids[0], cids[1]}
 	firstSession := sm.NewSession(ctx, time.Second, delay.Fixed(time.Minute)).(*fakeSession)
-	nextInterestedIn = true
+	nextInterestedIn = []cid.Cid{cids[0], cids[2]}
 	secondSession := sm.NewSession(ctx, time.Second, delay.Fixed(time.Minute)).(*fakeSession)
-	nextInterestedIn = false
+	nextInterestedIn = []cid.Cid{}
 	thirdSession := sm.NewSession(ctx, time.Second, delay.Fixed(time.Minute)).(*fakeSession)
 
-	sm.ReceiveBlockFrom(p, block)
-	if firstSession.receivedBlock ||
-		!secondSession.receivedBlock ||
-		thirdSession.receivedBlock {
-		t.Fatal("did not receive blocks only for interested sessions")
+	sm.ReceiveBlocksFrom(p, []blocks.Block{blks[0], blks[1]}, []blocks.Block{blks[2]}, true)
+
+	if !firstSession.fromNetwork ||
+		!secondSession.fromNetwork ||
+		!thirdSession.fromNetwork {
+		t.Fatal("did not receive correct fromNetwork for sessions")
+	}
+
+	if !cmpSessionCids(firstSession, []cid.Cid{cids[0], cids[1]}, []cid.Cid{}) ||
+		!cmpSessionCids(secondSession, []cid.Cid{cids[0]}, []cid.Cid{cids[2]}) ||
+		!cmpSessionCids(thirdSession, []cid.Cid{}, []cid.Cid{}) {
+		t.Fatal("did not receive correct blocks for sessions")
 	}
 }
 
@@ -146,7 +192,7 @@ func TestRemovingPeersWhenManagerContextCancelled(t *testing.T) {
 	p := peer.ID(123)
 	block := blocks.NewBlock([]byte("block"))
 	// we'll be interested in all blocks for this test
-	nextInterestedIn = true
+	nextInterestedIn = []cid.Cid{block.Cid()}
 	firstSession := sm.NewSession(ctx, time.Second, delay.Fixed(time.Minute)).(*fakeSession)
 	secondSession := sm.NewSession(ctx, time.Second, delay.Fixed(time.Minute)).(*fakeSession)
 	thirdSession := sm.NewSession(ctx, time.Second, delay.Fixed(time.Minute)).(*fakeSession)
@@ -154,10 +200,10 @@ func TestRemovingPeersWhenManagerContextCancelled(t *testing.T) {
 	cancel()
 	// wait for sessions to get removed
 	time.Sleep(10 * time.Millisecond)
-	sm.ReceiveBlockFrom(p, block)
-	if firstSession.receivedBlock ||
-		secondSession.receivedBlock ||
-		thirdSession.receivedBlock {
+	sm.ReceiveBlocksFrom(p, []blocks.Block{block}, []blocks.Block{}, true)
+	if len(firstSession.blks) > 0 ||
+		len(secondSession.blks) > 0 ||
+		len(thirdSession.blks) > 0 {
 		t.Fatal("received blocks for sessions after manager is shutdown")
 	}
 }
@@ -171,7 +217,7 @@ func TestRemovingPeersWhenSessionContextCancelled(t *testing.T) {
 	p := peer.ID(123)
 	block := blocks.NewBlock([]byte("block"))
 	// we'll be interested in all blocks for this test
-	nextInterestedIn = true
+	nextInterestedIn = []cid.Cid{block.Cid()}
 	firstSession := sm.NewSession(ctx, time.Second, delay.Fixed(time.Minute)).(*fakeSession)
 	sessionCtx, sessionCancel := context.WithCancel(ctx)
 	secondSession := sm.NewSession(sessionCtx, time.Second, delay.Fixed(time.Minute)).(*fakeSession)
@@ -180,10 +226,10 @@ func TestRemovingPeersWhenSessionContextCancelled(t *testing.T) {
 	sessionCancel()
 	// wait for sessions to get removed
 	time.Sleep(10 * time.Millisecond)
-	sm.ReceiveBlockFrom(p, block)
-	if !firstSession.receivedBlock ||
-		secondSession.receivedBlock ||
-		!thirdSession.receivedBlock {
+	sm.ReceiveBlocksFrom(p, []blocks.Block{block}, []blocks.Block{}, true)
+	if len(firstSession.blks) == 0 ||
+		len(secondSession.blks) > 0 ||
+		len(thirdSession.blks) == 0 {
 		t.Fatal("received blocks for sessions that are canceled")
 	}
 }

--- a/sessionpeermanager/latencytracker.go
+++ b/sessionpeermanager/latencytracker.go
@@ -56,10 +56,12 @@ func (lt *latencyTracker) RemoveRequest(key cid.Cid) {
 	}
 }
 
-func (lt *latencyTracker) RecordCancel(key cid.Cid) {
-	request, ok := lt.requests[key]
-	if ok {
-		request.wasCancelled = true
+func (lt *latencyTracker) RecordCancel(keys []cid.Cid) {
+	for _, key := range keys {
+		request, ok := lt.requests[key]
+		if ok {
+			request.wasCancelled = true
+		}
 	}
 }
 

--- a/sessionpeermanager/sessionpeermanager_test.go
+++ b/sessionpeermanager/sessionpeermanager_test.go
@@ -132,7 +132,7 @@ func TestRecordingReceivedBlocks(t *testing.T) {
 	id := testutil.GenerateSessionID()
 
 	sessionPeerManager := New(ctx, id, fpt, fppf)
-	sessionPeerManager.RecordPeerResponse(p, c)
+	sessionPeerManager.RecordPeerResponse(p, []cid.Cid{c})
 	time.Sleep(10 * time.Millisecond)
 	sessionPeers := getPeers(sessionPeerManager)
 	if len(sessionPeers) != 1 {
@@ -175,11 +175,11 @@ func TestOrderingPeers(t *testing.T) {
 	peer2 := peers[rand.Intn(100)]
 	peer3 := peers[rand.Intn(100)]
 	time.Sleep(1 * time.Millisecond)
-	sessionPeerManager.RecordPeerResponse(peer1, c[0])
+	sessionPeerManager.RecordPeerResponse(peer1, []cid.Cid{c[0]})
 	time.Sleep(5 * time.Millisecond)
-	sessionPeerManager.RecordPeerResponse(peer2, c[0])
+	sessionPeerManager.RecordPeerResponse(peer2, []cid.Cid{c[0]})
 	time.Sleep(1 * time.Millisecond)
-	sessionPeerManager.RecordPeerResponse(peer3, c[0])
+	sessionPeerManager.RecordPeerResponse(peer3, []cid.Cid{c[0]})
 
 	sessionPeers := sessionPeerManager.GetOptimizedPeers()
 	if len(sessionPeers) != maxOptimizedPeers {
@@ -215,7 +215,7 @@ func TestOrderingPeers(t *testing.T) {
 	sessionPeerManager.RecordPeerRequests(nil, c2)
 
 	// Receive a second time
-	sessionPeerManager.RecordPeerResponse(peer3, c2[0])
+	sessionPeerManager.RecordPeerResponse(peer3, []cid.Cid{c2[0]})
 
 	// call again
 	nextSessionPeers := sessionPeerManager.GetOptimizedPeers()
@@ -272,11 +272,11 @@ func TestTimeoutsAndCancels(t *testing.T) {
 	peer2 := peers[1]
 	peer3 := peers[2]
 	time.Sleep(1 * time.Millisecond)
-	sessionPeerManager.RecordPeerResponse(peer1, c[0])
+	sessionPeerManager.RecordPeerResponse(peer1, []cid.Cid{c[0]})
 	time.Sleep(2 * time.Millisecond)
-	sessionPeerManager.RecordPeerResponse(peer2, c[0])
+	sessionPeerManager.RecordPeerResponse(peer2, []cid.Cid{c[0]})
 	time.Sleep(40 * time.Millisecond)
-	sessionPeerManager.RecordPeerResponse(peer3, c[0])
+	sessionPeerManager.RecordPeerResponse(peer3, []cid.Cid{c[0]})
 
 	sessionPeers := sessionPeerManager.GetOptimizedPeers()
 
@@ -322,7 +322,7 @@ func TestTimeoutsAndCancels(t *testing.T) {
 
 	// Request again
 	sessionPeerManager.RecordPeerRequests([]peer.ID{peer2}, c3)
-	sessionPeerManager.RecordCancel(c3[0])
+	sessionPeerManager.RecordCancels([]cid.Cid{c3[0]})
 	// wait for a timeout
 	time.Sleep(40 * time.Millisecond)
 
@@ -339,9 +339,9 @@ func TestTimeoutsAndCancels(t *testing.T) {
 
 	// Request again
 	sessionPeerManager.RecordPeerRequests([]peer.ID{peer2}, c4)
-	sessionPeerManager.RecordCancel(c4[0])
+	sessionPeerManager.RecordCancels([]cid.Cid{c4[0]})
 	time.Sleep(2 * time.Millisecond)
-	sessionPeerManager.RecordPeerResponse(peer2, c4[0])
+	sessionPeerManager.RecordPeerResponse(peer2, []cid.Cid{c4[0]})
 	time.Sleep(2 * time.Millisecond)
 
 	// call again

--- a/sessionrequestsplitter/sessionrequestsplitter.go
+++ b/sessionrequestsplitter/sessionrequestsplitter.go
@@ -72,7 +72,7 @@ func (srs *SessionRequestSplitter) RecordDuplicateBlock() {
 	}
 }
 
-// RecordUniqueBlock records the fact that the session received unique block
+// RecordUniqueBlock records the fact that the session received a unique block
 // and adjusts the split factor as neccesary.
 func (srs *SessionRequestSplitter) RecordUniqueBlock() {
 	select {


### PR DESCRIPTION
When receiving a message, Bitswap processes each block in the message one-by-one. This causes problems with the session request splitter, which operates over groups of wants.

When the live want list is full and Bitswap processes a single block
- It opens one slot in the live want list (for the received block)
- It transfers as many items as possible from the tofetch queue into the live want list.
  *Because it has only freed one slot, it can only transfer one want from tofetch -> live wants*
- It "splits" the new wants in the live request queue across available peers
  *Because there's only one new want, it is trying to "split" a single CID, which doesn't make sense*

This PR changes Bitswap to process all the blocks from a received message as a batch, so that the request splitter can split a group of wants instead of a single want.