### PR TITLE
network: Allow specifying protocol prefix

### DIFF
--- a/network/options.go
+++ b/network/options.go
@@ -1,0 +1,15 @@
+package network
+
+import "github.com/libp2p/go-libp2p-core/protocol"
+
+type NetOpt func(*Settings)
+
+type Settings struct {
+	ProtocolPrefix protocol.ID
+}
+
+func Prefix(prefix protocol.ID) NetOpt {
+	return func(settings *Settings) {
+		settings.ProtocolPrefix = prefix
+	}
+}


### PR DESCRIPTION
I need multiple bitswap instances on one libp2p node, this allows me to make bitswap use strings like `/myproto/ipfs/bitswap/1.1.0` for protocols.