### PR TITLE
Refactor: use global pubsub notifier

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -330,7 +330,7 @@ func (bs *Bitswap) receiveBlocksFrom(from peer.ID, blks []blocks.Block) error {
 
 	// Send all block keys (including duplicates) to any sessions that want them.
 	// (The duplicates are needed by sessions for accounting purposes)
-	bs.sm.ReceiveBlocksFrom(from, allKs)
+	bs.sm.ReceiveFrom(from, allKs)
 
 	// Send wanted block keys to decision engine
 	bs.engine.AddBlocks(wantedKs)

--- a/decision/engine.go
+++ b/decision/engine.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/uuid"
 	bsmsg "github.com/ipfs/go-bitswap/message"
 	wl "github.com/ipfs/go-bitswap/wantlist"
-	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
 	logging "github.com/ipfs/go-log"
@@ -312,13 +311,13 @@ func (e *Engine) MessageReceived(p peer.ID, m bsmsg.BitSwapMessage) {
 	}
 }
 
-func (e *Engine) addBlocks(blocks []blocks.Block) {
+func (e *Engine) addBlocks(ks []cid.Cid) {
 	work := false
 
 	for _, l := range e.ledgerMap {
 		l.lk.Lock()
-		for _, block := range blocks {
-			if entry, ok := l.WantListContains(block.Cid()); ok {
+		for _, k := range ks {
+			if entry, ok := l.WantListContains(k); ok {
 				e.peerRequestQueue.PushBlock(l.Partner, peertask.Task{
 					Identifier: entry.Cid,
 					Priority:   entry.Priority,
@@ -337,11 +336,11 @@ func (e *Engine) addBlocks(blocks []blocks.Block) {
 // AddBlocks is called when new blocks are received and added to a block store,
 // meaning there may be peers who want those blocks, so we should send the blocks
 // to them.
-func (e *Engine) AddBlocks(blocks []blocks.Block) {
+func (e *Engine) AddBlocks(ks []cid.Cid) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
-	e.addBlocks(blocks)
+	e.addBlocks(ks)
 }
 
 // TODO add contents of m.WantList() to my local wantlist? NB: could introduce

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -60,8 +60,8 @@ func (ps *impl) Shutdown() {
 }
 
 // Subscribe returns a channel of blocks for the given |keys|. |blockChannel|
-// is closed if the |ctx| times out or is cancelled, or after sending len(keys)
-// blocks.
+// is closed if the |ctx| times out or is cancelled, or after receiving the blocks
+// corresponding to |keys|.
 func (ps *impl) Subscribe(ctx context.Context, keys ...cid.Cid) <-chan blocks.Block {
 
 	blocksCh := make(chan blocks.Block, len(keys))
@@ -82,6 +82,8 @@ func (ps *impl) Subscribe(ctx context.Context, keys ...cid.Cid) <-chan blocks.Bl
 	default:
 	}
 
+	// AddSubOnceEach listens for each key in the list, and closes the channel
+	// once all keys have been received
 	ps.wrapped.AddSubOnceEach(valuesCh, toStrings(keys)...)
 	go func() {
 		defer func() {

--- a/session/session.go
+++ b/session/session.go
@@ -182,7 +182,8 @@ func (s *Session) GetBlock(parent context.Context, k cid.Cid) (blocks.Block, err
 // guaranteed on the returned blocks.
 func (s *Session) GetBlocks(ctx context.Context, keys []cid.Cid) (<-chan blocks.Block, error) {
 	ctx = logging.ContextWithLoggable(ctx, s.uuid)
-	return bsgetter.AsyncGetBlocks(ctx, keys, s.notif,
+
+	return bsgetter.AsyncGetBlocks(ctx, s.ctx, keys, s.notif,
 		func(ctx context.Context, keys []cid.Cid) {
 			select {
 			case s.newReqs <- keys:

--- a/session/session.go
+++ b/session/session.go
@@ -52,9 +52,9 @@ type interestReq struct {
 	resp chan bool
 }
 
-type blksRecv struct {
+type rcvFrom struct {
 	from peer.ID
-	ks []cid.Cid
+	ks   []cid.Cid
 }
 
 // Session holds state for an individual bitswap transfer operation.
@@ -68,7 +68,7 @@ type Session struct {
 	srs RequestSplitter
 
 	// channels
-	incoming      chan blksRecv
+	incoming      chan rcvFrom
 	newReqs       chan []cid.Cid
 	cancelKeys    chan []cid.Cid
 	interestReqs  chan interestReq
@@ -117,7 +117,7 @@ func New(ctx context.Context,
 		wm:                  wm,
 		pm:                  pm,
 		srs:                 srs,
-		incoming:            make(chan blksRecv),
+		incoming:            make(chan rcvFrom),
 		notif:               notif,
 		uuid:                loggables.Uuid("GetBlockRequest"),
 		baseTickDelay:       time.Millisecond * 500,
@@ -134,10 +134,10 @@ func New(ctx context.Context,
 	return s
 }
 
-// ReceiveBlocksFrom receives incoming blocks from the given peer.
-func (s *Session) ReceiveBlocksFrom(from peer.ID, ks []cid.Cid) {
+// ReceiveFrom receives incoming blocks from the given peer.
+func (s *Session) ReceiveFrom(from peer.ID, ks []cid.Cid) {
 	select {
-	case s.incoming <- blksRecv{from: from, ks: ks}:
+	case s.incoming <- rcvFrom{from: from, ks: ks}:
 	case <-s.ctx.Done():
 	}
 }
@@ -232,13 +232,13 @@ func (s *Session) run(ctx context.Context) {
 	for {
 		select {
 		case rcv := <-s.incoming:
-			s.cancelIncomingBlocks(ctx, rcv)
+			s.cancelIncoming(ctx, rcv)
 			// Record statistics only if the blocks came from the network
 			// (blocks can also be received from the local node)
 			if rcv.from != "" {
 				s.updateReceiveCounters(ctx, rcv)
 			}
-			s.handleIncomingBlocks(ctx, rcv)
+			s.handleIncoming(ctx, rcv)
 		case keys := <-s.newReqs:
 			s.handleNewRequest(ctx, keys)
 		case keys := <-s.cancelKeys:
@@ -260,7 +260,7 @@ func (s *Session) run(ctx context.Context) {
 	}
 }
 
-func (s *Session) cancelIncomingBlocks(ctx context.Context, rcv blksRecv) {
+func (s *Session) cancelIncoming(ctx context.Context, rcv rcvFrom) {
 	// We've received the blocks so we can cancel any outstanding wants for them
 	wanted := make([]cid.Cid, 0, len(rcv.ks))
 	for _, k := range rcv.ks {
@@ -272,11 +272,11 @@ func (s *Session) cancelIncomingBlocks(ctx context.Context, rcv blksRecv) {
 	s.wm.CancelWants(s.ctx, wanted, nil, s.id)
 }
 
-func (s *Session) handleIncomingBlocks(ctx context.Context, rcv blksRecv) {
+func (s *Session) handleIncoming(ctx context.Context, rcv rcvFrom) {
 	s.idleTick.Stop()
 
 	// Process the received blocks
-	s.receiveBlocks(ctx, rcv.ks)
+	s.processIncoming(ctx, rcv.ks)
 
 	s.resetIdleTick()
 }
@@ -376,7 +376,7 @@ func (s *Session) cidIsWanted(c cid.Cid) bool {
 	return ok
 }
 
-func (s *Session) receiveBlocks(ctx context.Context, ks []cid.Cid) {
+func (s *Session) processIncoming(ctx context.Context, ks []cid.Cid) {
 	for _, c := range ks {
 		if s.cidIsWanted(c) {
 			// If the block CID was in the live wants queue, remove it
@@ -414,7 +414,7 @@ func (s *Session) receiveBlocks(ctx context.Context, ks []cid.Cid) {
 	}
 }
 
-func (s *Session) updateReceiveCounters(ctx context.Context, rcv blksRecv) {
+func (s *Session) updateReceiveCounters(ctx context.Context, rcv rcvFrom) {
 	for _, k := range rcv.ks {
 		// Inform the request splitter of unique / duplicate blocks
 		if s.cidIsWanted(k) {

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -129,7 +129,7 @@ func TestSessionGetBlocks(t *testing.T) {
 		// - calls ReceiveBlocksFrom() on session
 		// - publishes block to pubsub channel
 		blk := blks[testutil.IndexOf(blks, receivedWantReq.cids[i])]
-		session.ReceiveBlocksFrom(p, []blocks.Block{blk})
+		session.ReceiveBlocksFrom(p, []cid.Cid{blk.Cid()})
 		notif.Publish(blk)
 
 		select {
@@ -191,7 +191,7 @@ func TestSessionGetBlocks(t *testing.T) {
 		// - calls ReceiveBlocksFrom() on session
 		// - publishes block to pubsub channel
 		blk := blks[testutil.IndexOf(blks, newCidsRequested[i])]
-		session.ReceiveBlocksFrom(p, []blocks.Block{blk})
+		session.ReceiveBlocksFrom(p, []cid.Cid{blk.Cid()})
 		notif.Publish(blk)
 
 		receivedBlock := <-getBlocksCh
@@ -255,7 +255,7 @@ func TestSessionFindMorePeers(t *testing.T) {
 	// - calls ReceiveBlocksFrom() on session
 	// - publishes block to pubsub channel
 	blk := blks[0]
-	session.ReceiveBlocksFrom(p, []blocks.Block{blk})
+	session.ReceiveBlocksFrom(p, []cid.Cid{blk.Cid()})
 	notif.Publish(blk)
 	select {
 	case <-cancelReqs:

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -126,10 +126,10 @@ func TestSessionGetBlocks(t *testing.T) {
 	var receivedBlocks []blocks.Block
 	for i, p := range peers {
 		// simulate what bitswap does on receiving a message:
-		// - calls ReceiveBlocksFrom() on session
+		// - calls ReceiveFrom() on session
 		// - publishes block to pubsub channel
 		blk := blks[testutil.IndexOf(blks, receivedWantReq.cids[i])]
-		session.ReceiveBlocksFrom(p, []cid.Cid{blk.Cid()})
+		session.ReceiveFrom(p, []cid.Cid{blk.Cid()})
 		notif.Publish(blk)
 
 		select {
@@ -188,10 +188,10 @@ func TestSessionGetBlocks(t *testing.T) {
 	// receive remaining blocks
 	for i, p := range peers {
 		// simulate what bitswap does on receiving a message:
-		// - calls ReceiveBlocksFrom() on session
+		// - calls ReceiveFrom() on session
 		// - publishes block to pubsub channel
 		blk := blks[testutil.IndexOf(blks, newCidsRequested[i])]
-		session.ReceiveBlocksFrom(p, []cid.Cid{blk.Cid()})
+		session.ReceiveFrom(p, []cid.Cid{blk.Cid()})
 		notif.Publish(blk)
 
 		receivedBlock := <-getBlocksCh
@@ -252,10 +252,10 @@ func TestSessionFindMorePeers(t *testing.T) {
 	p := testutil.GeneratePeers(1)[0]
 
 	// simulate what bitswap does on receiving a message:
-	// - calls ReceiveBlocksFrom() on session
+	// - calls ReceiveFrom() on session
 	// - publishes block to pubsub channel
 	blk := blks[0]
-	session.ReceiveBlocksFrom(p, []cid.Cid{blk.Cid()})
+	session.ReceiveFrom(p, []cid.Cid{blk.Cid()})
 	notif.Publish(blk)
 	select {
 	case <-cancelReqs:

--- a/sessionmanager/sessionmanager.go
+++ b/sessionmanager/sessionmanager.go
@@ -18,7 +18,7 @@ import (
 type Session interface {
 	exchange.Fetcher
 	InterestedIn(cid.Cid) bool
-	ReceiveBlocksFrom(peer.ID, []cid.Cid)
+	ReceiveFrom(peer.ID, []cid.Cid)
 }
 
 type sesTrk struct {
@@ -114,9 +114,9 @@ func (sm *SessionManager) GetNextSessionID() uint64 {
 	return sm.sessID
 }
 
-// ReceiveBlocksFrom receives blocks from a peer and dispatches to interested
+// ReceiveFrom receives blocks from a peer and dispatches to interested
 // sessions.
-func (sm *SessionManager) ReceiveBlocksFrom(from peer.ID, ks []cid.Cid) {
+func (sm *SessionManager) ReceiveFrom(from peer.ID, ks []cid.Cid) {
 	sm.sessLk.Lock()
 	defer sm.sessLk.Unlock()
 
@@ -128,6 +128,6 @@ func (sm *SessionManager) ReceiveBlocksFrom(from peer.ID, ks []cid.Cid) {
 				sessKs = append(sessKs, k)
 			}
 		}
-		s.session.ReceiveBlocksFrom(from, sessKs)
+		s.session.ReceiveFrom(from, sessKs)
 	}
 }

--- a/sessionmanager/sessionmanager.go
+++ b/sessionmanager/sessionmanager.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 	delay "github.com/ipfs/go-ipfs-delay"
 
@@ -19,7 +18,7 @@ import (
 type Session interface {
 	exchange.Fetcher
 	InterestedIn(cid.Cid) bool
-	ReceiveBlocksFrom(peer.ID, []blocks.Block)
+	ReceiveBlocksFrom(peer.ID, []cid.Cid)
 }
 
 type sesTrk struct {
@@ -117,18 +116,18 @@ func (sm *SessionManager) GetNextSessionID() uint64 {
 
 // ReceiveBlocksFrom receives blocks from a peer and dispatches to interested
 // sessions.
-func (sm *SessionManager) ReceiveBlocksFrom(from peer.ID, blks []blocks.Block) {
+func (sm *SessionManager) ReceiveBlocksFrom(from peer.ID, ks []cid.Cid) {
 	sm.sessLk.Lock()
 	defer sm.sessLk.Unlock()
 
 	// Only give each session the blocks / dups that it is interested in
 	for _, s := range sm.sessions {
-		sessBlks := make([]blocks.Block, 0, len(blks))
-		for _, b := range blks {
-			if s.session.InterestedIn(b.Cid()) {
-				sessBlks = append(sessBlks, b)
+		sessKs := make([]cid.Cid, 0, len(ks))
+		for _, k := range ks {
+			if s.session.InterestedIn(k) {
+				sessKs = append(sessKs, k)
 			}
 		}
-		s.session.ReceiveBlocksFrom(from, sessBlks)
+		s.session.ReceiveBlocksFrom(from, sessKs)
 	}
 }

--- a/sessionmanager/sessionmanager_test.go
+++ b/sessionmanager/sessionmanager_test.go
@@ -7,6 +7,7 @@ import (
 
 	delay "github.com/ipfs/go-ipfs-delay"
 
+	notifications "github.com/ipfs/go-bitswap/notifications"
 	bssession "github.com/ipfs/go-bitswap/session"
 	bssd "github.com/ipfs/go-bitswap/sessiondata"
 	"github.com/ipfs/go-bitswap/testutil"
@@ -22,6 +23,7 @@ type fakeSession struct {
 	id         uint64
 	pm         *fakePeerManager
 	srs        *fakeRequestSplitter
+	notif      notifications.PubSub
 }
 
 func (*fakeSession) GetBlock(context.Context, cid.Cid) (blocks.Block, error) {
@@ -67,6 +69,7 @@ func sessionFactory(ctx context.Context,
 	id uint64,
 	pm bssession.PeerManager,
 	srs bssession.RequestSplitter,
+	notif notifications.PubSub,
 	provSearchDelay time.Duration,
 	rebroadcastDelay delay.D) Session {
 	return &fakeSession{
@@ -74,6 +77,7 @@ func sessionFactory(ctx context.Context,
 		id:         id,
 		pm:         pm.(*fakePeerManager),
 		srs:        srs.(*fakeRequestSplitter),
+		notif:      notif,
 	}
 }
 
@@ -111,7 +115,9 @@ func TestAddingSessions(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	sm := New(ctx, sessionFactory, peerManagerFactory, requestSplitterFactory)
+	notif := notifications.New()
+	defer notif.Shutdown()
+	sm := New(ctx, sessionFactory, peerManagerFactory, requestSplitterFactory, notif)
 
 	p := peer.ID(123)
 	block := blocks.NewBlock([]byte("block"))
@@ -147,7 +153,9 @@ func TestReceivingBlocksWhenNotInterested(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	sm := New(ctx, sessionFactory, peerManagerFactory, requestSplitterFactory)
+	notif := notifications.New()
+	defer notif.Shutdown()
+	sm := New(ctx, sessionFactory, peerManagerFactory, requestSplitterFactory, notif)
 
 	p := peer.ID(123)
 	blks := testutil.GenerateBlocksOfSize(3, 1024)
@@ -175,7 +183,9 @@ func TestReceivingBlocksWhenNotInterested(t *testing.T) {
 func TestRemovingPeersWhenManagerContextCancelled(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
-	sm := New(ctx, sessionFactory, peerManagerFactory, requestSplitterFactory)
+	notif := notifications.New()
+	defer notif.Shutdown()
+	sm := New(ctx, sessionFactory, peerManagerFactory, requestSplitterFactory, notif)
 
 	p := peer.ID(123)
 	block := blocks.NewBlock([]byte("block"))
@@ -200,7 +210,9 @@ func TestRemovingPeersWhenSessionContextCancelled(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	sm := New(ctx, sessionFactory, peerManagerFactory, requestSplitterFactory)
+	notif := notifications.New()
+	defer notif.Shutdown()
+	sm := New(ctx, sessionFactory, peerManagerFactory, requestSplitterFactory, notif)
 
 	p := peer.ID(123)
 	block := blocks.NewBlock([]byte("block"))

--- a/sessionmanager/sessionmanager_test.go
+++ b/sessionmanager/sessionmanager_test.go
@@ -40,7 +40,7 @@ func (fs *fakeSession) InterestedIn(c cid.Cid) bool {
 	}
 	return false
 }
-func (fs *fakeSession) ReceiveBlocksFrom(p peer.ID, ks []cid.Cid) {
+func (fs *fakeSession) ReceiveFrom(p peer.ID, ks []cid.Cid) {
 	fs.ks = append(fs.ks, ks...)
 }
 
@@ -137,7 +137,7 @@ func TestAddingSessions(t *testing.T) {
 		thirdSession.id != secondSession.id+2 {
 		t.Fatal("session does not have correct id set")
 	}
-	sm.ReceiveBlocksFrom(p, []cid.Cid{block.Cid()})
+	sm.ReceiveFrom(p, []cid.Cid{block.Cid()})
 	if len(firstSession.ks) == 0 ||
 		len(secondSession.ks) == 0 ||
 		len(thirdSession.ks) == 0 {
@@ -167,7 +167,7 @@ func TestReceivingBlocksWhenNotInterested(t *testing.T) {
 	nextInterestedIn = []cid.Cid{}
 	thirdSession := sm.NewSession(ctx, time.Second, delay.Fixed(time.Minute)).(*fakeSession)
 
-	sm.ReceiveBlocksFrom(p, []cid.Cid{blks[0].Cid(), blks[1].Cid()})
+	sm.ReceiveFrom(p, []cid.Cid{blks[0].Cid(), blks[1].Cid()})
 
 	if !cmpSessionCids(firstSession, []cid.Cid{cids[0], cids[1]}) ||
 		!cmpSessionCids(secondSession, []cid.Cid{cids[0]}) ||
@@ -194,7 +194,7 @@ func TestRemovingPeersWhenManagerContextCancelled(t *testing.T) {
 	cancel()
 	// wait for sessions to get removed
 	time.Sleep(10 * time.Millisecond)
-	sm.ReceiveBlocksFrom(p, []cid.Cid{block.Cid()})
+	sm.ReceiveFrom(p, []cid.Cid{block.Cid()})
 	if len(firstSession.ks) > 0 ||
 		len(secondSession.ks) > 0 ||
 		len(thirdSession.ks) > 0 {
@@ -222,7 +222,7 @@ func TestRemovingPeersWhenSessionContextCancelled(t *testing.T) {
 	sessionCancel()
 	// wait for sessions to get removed
 	time.Sleep(10 * time.Millisecond)
-	sm.ReceiveBlocksFrom(p, []cid.Cid{block.Cid()})
+	sm.ReceiveFrom(p, []cid.Cid{block.Cid()})
 	if len(firstSession.ks) == 0 ||
 		len(secondSession.ks) > 0 ||
 		len(thirdSession.ks) == 0 {

--- a/sessionmanager/sessionmanager_test.go
+++ b/sessionmanager/sessionmanager_test.go
@@ -19,7 +19,7 @@ import (
 
 type fakeSession struct {
 	interested []cid.Cid
-	blks       []blocks.Block
+	ks         []cid.Cid
 	id         uint64
 	pm         *fakePeerManager
 	srs        *fakeRequestSplitter
@@ -40,8 +40,8 @@ func (fs *fakeSession) InterestedIn(c cid.Cid) bool {
 	}
 	return false
 }
-func (fs *fakeSession) ReceiveBlocksFrom(p peer.ID, blks []blocks.Block) {
-	fs.blks = append(fs.blks, blks...)
+func (fs *fakeSession) ReceiveBlocksFrom(p peer.ID, ks []cid.Cid) {
+	fs.ks = append(fs.ks, ks...)
 }
 
 type fakePeerManager struct {
@@ -90,17 +90,13 @@ func requestSplitterFactory(ctx context.Context) bssession.RequestSplitter {
 }
 
 func cmpSessionCids(s *fakeSession, cids []cid.Cid) bool {
-	return cmpBlockCids(s.blks, cids)
-}
-
-func cmpBlockCids(blks []blocks.Block, cids []cid.Cid) bool {
-	if len(blks) != len(cids) {
+	if len(s.ks) != len(cids) {
 		return false
 	}
-	for _, b := range blks {
+	for _, bk := range s.ks {
 		has := false
 		for _, c := range cids {
-			if c == b.Cid() {
+			if c == bk {
 				has = true
 			}
 		}
@@ -141,10 +137,10 @@ func TestAddingSessions(t *testing.T) {
 		thirdSession.id != secondSession.id+2 {
 		t.Fatal("session does not have correct id set")
 	}
-	sm.ReceiveBlocksFrom(p, []blocks.Block{block})
-	if len(firstSession.blks) == 0 ||
-		len(secondSession.blks) == 0 ||
-		len(thirdSession.blks) == 0 {
+	sm.ReceiveBlocksFrom(p, []cid.Cid{block.Cid()})
+	if len(firstSession.ks) == 0 ||
+		len(secondSession.ks) == 0 ||
+		len(thirdSession.ks) == 0 {
 		t.Fatal("should have received blocks but didn't")
 	}
 }
@@ -171,7 +167,7 @@ func TestReceivingBlocksWhenNotInterested(t *testing.T) {
 	nextInterestedIn = []cid.Cid{}
 	thirdSession := sm.NewSession(ctx, time.Second, delay.Fixed(time.Minute)).(*fakeSession)
 
-	sm.ReceiveBlocksFrom(p, []blocks.Block{blks[0], blks[1]})
+	sm.ReceiveBlocksFrom(p, []cid.Cid{blks[0].Cid(), blks[1].Cid()})
 
 	if !cmpSessionCids(firstSession, []cid.Cid{cids[0], cids[1]}) ||
 		!cmpSessionCids(secondSession, []cid.Cid{cids[0]}) ||
@@ -198,10 +194,10 @@ func TestRemovingPeersWhenManagerContextCancelled(t *testing.T) {
 	cancel()
 	// wait for sessions to get removed
 	time.Sleep(10 * time.Millisecond)
-	sm.ReceiveBlocksFrom(p, []blocks.Block{block})
-	if len(firstSession.blks) > 0 ||
-		len(secondSession.blks) > 0 ||
-		len(thirdSession.blks) > 0 {
+	sm.ReceiveBlocksFrom(p, []cid.Cid{block.Cid()})
+	if len(firstSession.ks) > 0 ||
+		len(secondSession.ks) > 0 ||
+		len(thirdSession.ks) > 0 {
 		t.Fatal("received blocks for sessions after manager is shutdown")
 	}
 }
@@ -226,10 +222,10 @@ func TestRemovingPeersWhenSessionContextCancelled(t *testing.T) {
 	sessionCancel()
 	// wait for sessions to get removed
 	time.Sleep(10 * time.Millisecond)
-	sm.ReceiveBlocksFrom(p, []blocks.Block{block})
-	if len(firstSession.blks) == 0 ||
-		len(secondSession.blks) > 0 ||
-		len(thirdSession.blks) == 0 {
+	sm.ReceiveBlocksFrom(p, []cid.Cid{block.Cid()})
+	if len(firstSession.ks) == 0 ||
+		len(secondSession.ks) > 0 ||
+		len(thirdSession.ks) == 0 {
 		t.Fatal("received blocks for sessions that are canceled")
 	}
 }


### PR DESCRIPTION
This will enable us to pass around CIDs instead of Blocks (Fixes https://github.com/ipfs/go-bitswap/issues/173)