### PR TITLE
Parallelize engine reads

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -374,7 +374,7 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 
 	// This call records changes to wantlists, blocks received,
 	// and number of bytes transfered.
-	bs.engine.MessageReceived(p, incoming)
+	bs.engine.MessageReceived(ctx, p, incoming)
 	// TODO: this is bad, and could be easily abused.
 	// Should only track *useful* messages in ledger
 

--- a/bitswap.go
+++ b/bitswap.go
@@ -130,9 +130,10 @@ func New(parent context.Context, network bsnet.BitSwapNetwork,
 	}
 	notif := notifications.New()
 
+	engine := decision.NewEngine(ctx, bstore, network.ConnectionManager()) // TODO close the engine with Close() method
 	bs := &Bitswap{
 		blockstore:       bstore,
-		engine:           decision.NewEngine(ctx, bstore, network.ConnectionManager()), // TODO close the engine with Close() method
+		engine:           engine,
 		network:          network,
 		process:          px,
 		newBlocks:        make(chan cid.Cid, HasBlockBufferSize),
@@ -161,6 +162,7 @@ func New(parent context.Context, network bsnet.BitSwapNetwork,
 
 	// Start up bitswaps async worker routines
 	bs.startWorkers(ctx, px)
+	engine.StartWorkers(ctx, px)
 
 	// bind the context and process.
 	// do it over here to avoid closing before all setup is done.

--- a/decision/blockstoremanager.go
+++ b/decision/blockstoremanager.go
@@ -1,0 +1,115 @@
+package decision
+
+import (
+	"context"
+	"sync"
+
+	blocks "github.com/ipfs/go-block-format"
+	cid "github.com/ipfs/go-cid"
+	bstore "github.com/ipfs/go-ipfs-blockstore"
+	process "github.com/jbenet/goprocess"
+)
+
+// blockstoreManager maintains a pool of workers that make requests to the blockstore.
+type blockstoreManager struct {
+	bs bstore.Blockstore
+	// workerLock sync.Mutex
+	workerCount int
+	jobs        chan func()
+}
+
+// newBlockstoreManager creates a new blockstoreManager with the given context
+// and number of workers
+func newBlockstoreManager(ctx context.Context, bs bstore.Blockstore, workerCount int) *blockstoreManager {
+	return &blockstoreManager{
+		bs:          bs,
+		workerCount: workerCount,
+		jobs:        make(chan func(), 1),
+	}
+}
+
+func (bsm *blockstoreManager) start(ctx context.Context, px process.Process) {
+	// Start up workers
+	for i := 0; i < bsm.workerCount; i++ {
+		i := i
+		px.Go(func(px process.Process) {
+			bsm.worker(ctx, i)
+		})
+	}
+}
+
+func (bsm *blockstoreManager) worker(ctx context.Context, id int) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case job := <-bsm.jobs:
+			job()
+		}
+	}
+}
+
+func (bsm *blockstoreManager) addJob(job func()) {
+	bsm.jobs <- job
+}
+
+func (bsm *blockstoreManager) getBlockSizes(ks []cid.Cid) map[cid.Cid]int {
+	res := make(map[cid.Cid]int)
+	if len(ks) == 0 {
+		return res
+	}
+
+	var lk sync.Mutex
+	bsm.jobPerKey(ks, func(c cid.Cid) {
+		size, err := bsm.bs.GetSize(c)
+		if err != nil {
+			if err != bstore.ErrNotFound {
+				log.Warningf("blockstore.GetSize(%s) error: %s", c, err)
+			}
+			size = 0
+		}
+
+		lk.Lock()
+		res[c] = size
+		lk.Unlock()
+	})
+
+	return res
+}
+
+func (bsm *blockstoreManager) getBlocks(ks []cid.Cid) map[cid.Cid]blocks.Block {
+	res := make(map[cid.Cid]blocks.Block)
+	if len(ks) == 0 {
+		return res
+	}
+
+	var lk sync.Mutex
+	bsm.jobPerKey(ks, func(c cid.Cid) {
+		blk, err := bsm.bs.Get(c)
+		if err != nil {
+			blk = nil
+			if err != bstore.ErrNotFound {
+				log.Warningf("blockstore.Get(%s) error: %s", c, err)
+			}
+		}
+
+		lk.Lock()
+		res[c] = blk
+		lk.Unlock()
+	})
+
+	return res
+}
+
+func (bsm *blockstoreManager) jobPerKey(ks []cid.Cid, jobFn func(c cid.Cid)) {
+	wg := sync.WaitGroup{}
+	for _, k := range ks {
+		c := k
+		wg.Add(1)
+		bsm.addJob(func() {
+			jobFn(c)
+			wg.Done()
+		})
+	}
+	wg.Wait()
+}

--- a/decision/blockstoremanager.go
+++ b/decision/blockstoremanager.go
@@ -69,7 +69,7 @@ func (bsm *blockstoreManager) getBlockSizes(ctx context.Context, ks []cid.Cid) m
 		size, err := bsm.bs.GetSize(c)
 		if err != nil {
 			if err != bstore.ErrNotFound {
-				log.Warningf("blockstore.GetSize(%s) error: %s", c, err)
+				log.Errorf("blockstore.GetSize(%s) error: %s", c, err)
 			}
 		} else {
 			lk.Lock()
@@ -92,7 +92,7 @@ func (bsm *blockstoreManager) getBlocks(ctx context.Context, ks []cid.Cid) map[c
 		blk, err := bsm.bs.Get(c)
 		if err != nil {
 			if err != bstore.ErrNotFound {
-				log.Warningf("blockstore.Get(%s) error: %s", c, err)
+				log.Errorf("blockstore.Get(%s) error: %s", c, err)
 			}
 		} else {
 			lk.Lock()

--- a/decision/blockstoremanager.go
+++ b/decision/blockstoremanager.go
@@ -24,7 +24,7 @@ func newBlockstoreManager(ctx context.Context, bs bstore.Blockstore, workerCount
 	return &blockstoreManager{
 		bs:          bs,
 		workerCount: workerCount,
-		jobs:        make(chan func(), 1),
+		jobs:        make(chan func()),
 	}
 }
 

--- a/decision/blockstoremanager.go
+++ b/decision/blockstoremanager.go
@@ -12,8 +12,7 @@ import (
 
 // blockstoreManager maintains a pool of workers that make requests to the blockstore.
 type blockstoreManager struct {
-	bs bstore.Blockstore
-	// workerLock sync.Mutex
+	bs          bstore.Blockstore
 	workerCount int
 	jobs        chan func()
 }

--- a/decision/blockstoremanager_test.go
+++ b/decision/blockstoremanager_test.go
@@ -195,6 +195,8 @@ func TestBlockstoreManagerClose(t *testing.T) {
 
 	go px.Close()
 
+	time.Sleep(5 * time.Millisecond)
+
 	fnCallDone := make(chan struct{})
 	go func() {
 		bsm.getBlockSizes(ctx, ks)

--- a/decision/blockstoremanager_test.go
+++ b/decision/blockstoremanager_test.go
@@ -3,6 +3,7 @@ package decision
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -120,6 +121,7 @@ func TestBlockstoreManagerConcurrency(t *testing.T) {
 	}
 
 	// Create more concurrent requests than the number of workers
+	var err error
 	wg := sync.WaitGroup{}
 	for i := 0; i < 16; i++ {
 		wg.Add(1)
@@ -129,15 +131,19 @@ func TestBlockstoreManagerConcurrency(t *testing.T) {
 
 			sizes := bsm.getBlockSizes(ks)
 			if len(sizes) != len(ks) {
-				t.Fatal("Wrong response length")
+				err = errors.New("Wrong response length")
 			}
 
 			for _, c := range ks {
 				if sizes[c] != 0 {
-					t.Fatal("Non-existent block should have size 0")
+					err = errors.New("Non-existent block should have size 0")
 				}
 			}
 		}(t)
 	}
 	wg.Wait()
+
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/decision/blockstoremanager_test.go
+++ b/decision/blockstoremanager_test.go
@@ -147,10 +147,12 @@ func TestBlockstoreManagerConcurrency(t *testing.T) {
 		ks = append(ks, b.Cid())
 	}
 
-	bstore.PutMany(blks)
+	err := bstore.PutMany(blks)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Create more concurrent requests than the number of workers
-	var err error
 	wg := sync.WaitGroup{}
 	for i := 0; i < 16; i++ {
 		wg.Add(1)

--- a/decision/blockstoremanager_test.go
+++ b/decision/blockstoremanager_test.go
@@ -1,0 +1,143 @@
+package decision
+
+import (
+	"context"
+	"crypto/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-bitswap/testutil"
+	cid "github.com/ipfs/go-cid"
+
+	blocks "github.com/ipfs/go-block-format"
+	ds "github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/delayed"
+	ds_sync "github.com/ipfs/go-datastore/sync"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	delay "github.com/ipfs/go-ipfs-delay"
+	process "github.com/jbenet/goprocess"
+)
+
+func TestBlockstoreManagerNotFoundKey(t *testing.T) {
+	ctx := context.Background()
+	bsdelay := delay.Fixed(3 * time.Millisecond)
+	dstore := ds_sync.MutexWrap(delayed.New(ds.NewMapDatastore(), bsdelay))
+	bstore := blockstore.NewBlockstore(ds_sync.MutexWrap(dstore))
+
+	bsm := newBlockstoreManager(ctx, bstore, 5)
+	bsm.start(ctx, process.WithTeardown(func() error { return nil }))
+
+	cids := testutil.GenerateCids(4)
+	sizes := bsm.getBlockSizes(cids)
+	if len(sizes) != len(cids) {
+		t.Fatal("Wrong response length")
+	}
+
+	for _, c := range cids {
+		if sizes[c] != 0 {
+			t.Fatal("Non-existent block should have size 0")
+		}
+	}
+
+	blks := bsm.getBlocks(cids)
+	if len(blks) != len(cids) {
+		t.Fatal("Wrong response length")
+	}
+
+	for _, b := range blks {
+		if b != nil {
+			t.Fatal("Non-existent block should be nil")
+		}
+	}
+}
+
+func TestBlockstoreManager(t *testing.T) {
+	ctx := context.Background()
+	bsdelay := delay.Fixed(3 * time.Millisecond)
+	dstore := ds_sync.MutexWrap(delayed.New(ds.NewMapDatastore(), bsdelay))
+	bstore := blockstore.NewBlockstore(ds_sync.MutexWrap(dstore))
+
+	bsm := newBlockstoreManager(ctx, bstore, 5)
+	bsm.start(ctx, process.WithTeardown(func() error { return nil }))
+
+	exp := make(map[cid.Cid]blocks.Block)
+	var blks []blocks.Block
+	for i := 0; i < 32; i++ {
+		buf := make([]byte, 1024*(i+1))
+		_, _ = rand.Read(buf)
+		b := blocks.NewBlock(buf)
+		blks = append(blks, b)
+		exp[b.Cid()] = b
+	}
+	if err := bstore.PutMany(blks); err != nil {
+		t.Fatal(err)
+	}
+
+	var cids []cid.Cid
+	for _, b := range blks {
+		cids = append(cids, b.Cid())
+	}
+
+	sizes := bsm.getBlockSizes(cids)
+	if len(sizes) != len(cids) {
+		t.Fatal("Wrong response length")
+	}
+
+	for _, c := range cids {
+		expSize := len(exp[c].RawData())
+		if sizes[c] != expSize {
+			t.Fatal("Block should have size ", expSize)
+		}
+	}
+
+	fetched := bsm.getBlocks(cids)
+	if len(fetched) != len(cids) {
+		t.Fatal("Wrong response length")
+	}
+
+	for _, c := range cids {
+		if fetched[c].Cid() != c {
+			t.Fatal("Block should have cid ", c)
+		}
+	}
+}
+
+func TestBlockstoreManagerConcurrency(t *testing.T) {
+	ctx := context.Background()
+	bsdelay := delay.Fixed(3 * time.Millisecond)
+	dstore := ds_sync.MutexWrap(delayed.New(ds.NewMapDatastore(), bsdelay))
+	bstore := blockstore.NewBlockstore(ds_sync.MutexWrap(dstore))
+
+	workerCount := 5
+	bsm := newBlockstoreManager(ctx, bstore, workerCount)
+	bsm.start(ctx, process.WithTeardown(func() error { return nil }))
+
+	blks := testutil.GenerateBlocksOfSize(32, 8*1024)
+	var ks []cid.Cid
+	for _, b := range blks {
+		ks = append(ks, b.Cid())
+	}
+
+	// Create more concurrent requests than the number of workers
+	wg := sync.WaitGroup{}
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+
+		go func(t *testing.T) {
+			defer wg.Done()
+
+			sizes := bsm.getBlockSizes(ks)
+			if len(sizes) != len(ks) {
+				t.Fatal("Wrong response length")
+			}
+
+			for _, c := range ks {
+				if sizes[c] != 0 {
+					t.Fatal("Non-existent block should have size 0")
+				}
+			}
+		}(t)
+	}
+	wg.Wait()
+}

--- a/decision/engine.go
+++ b/decision/engine.go
@@ -170,7 +170,7 @@ func NewEngine(ctx context.Context, bs bstore.Blockstore, peerTagger PeerTagger)
 // Start up workers to handle requests from other nodes for the data on this node
 func (e *Engine) StartWorkers(ctx context.Context, px process.Process) {
 	// Start up blockstore manager
-	e.bsm.start(ctx, px)
+	e.bsm.start(px)
 
 	for i := 0; i < e.taskWorkerCount; i++ {
 		px.Go(func(px process.Process) {

--- a/decision/engine.go
+++ b/decision/engine.go
@@ -81,6 +81,9 @@ const (
 	// long/short term scores for tagging peers
 	longTermScore  = 10 // this is a high tag but it grows _very_ slowly.
 	shortTermScore = 10 // this is a high tag but it'll go away quickly if we aren't using the peer.
+
+	// Number of concurrent workers that process requests to the blockstore
+	blockstoreWorkerCount = 128
 )
 
 var (
@@ -128,7 +131,7 @@ type Engine struct {
 	// taskWorker goroutine
 	outbox chan (<-chan *Envelope)
 
-	bs bstore.Blockstore
+	bsm *blockstoreManager
 
 	peerTagger PeerTagger
 
@@ -148,7 +151,7 @@ type Engine struct {
 func NewEngine(ctx context.Context, bs bstore.Blockstore, peerTagger PeerTagger) *Engine {
 	e := &Engine{
 		ledgerMap:       make(map[peer.ID]*ledger),
-		bs:              bs,
+		bsm:             newBlockstoreManager(ctx, bs, blockstoreWorkerCount),
 		peerTagger:      peerTagger,
 		outbox:          make(chan (<-chan *Envelope), outboxChanBuffer),
 		workSignal:      make(chan struct{}, 1),
@@ -166,6 +169,9 @@ func NewEngine(ctx context.Context, bs bstore.Blockstore, peerTagger PeerTagger)
 
 // Start up workers to handle requests from other nodes for the data on this node
 func (e *Engine) StartWorkers(ctx context.Context, px process.Process) {
+	// Start up blockstore manager
+	e.bsm.start(ctx, px)
+
 	for i := 0; i < e.taskWorkerCount; i++ {
 		px.Go(func(px process.Process) {
 			e.taskWorker(ctx)
@@ -357,14 +363,15 @@ func (e *Engine) nextEnvelope(ctx context.Context) (*Envelope, error) {
 		}
 
 		// with a task in hand, we're ready to prepare the envelope...
+		blockCids := cid.NewSet()
+		for _, t := range nextTask.Tasks {
+			blockCids.Add(t.Identifier.(cid.Cid))
+		}
+		blks := e.bsm.getBlocks(blockCids.Keys())
+
 		msg := bsmsg.New(true)
-		for _, entry := range nextTask.Tasks {
-			block, err := e.bs.Get(entry.Identifier.(cid.Cid))
-			if err != nil {
-				log.Errorf("tried to execute a task and errored fetching block: %s", err)
-				continue
-			}
-			msg.AddBlock(block)
+		for _, b := range blks {
+			msg.AddBlock(b)
 		}
 
 		if msg.Empty() {
@@ -422,6 +429,16 @@ func (e *Engine) MessageReceived(p peer.ID, m bsmsg.BitSwapMessage) {
 		}
 	}()
 
+	// Get block sizes
+	entries := m.Wantlist()
+	wantKs := cid.NewSet()
+	for _, entry := range entries {
+		if !entry.Cancel {
+			wantKs.Add(entry.Cid)
+		}
+	}
+	blockSizes := e.bsm.getBlockSizes(wantKs.Keys())
+
 	l := e.findOrCreate(p)
 	l.lk.Lock()
 	defer l.lk.Unlock()
@@ -439,13 +456,8 @@ func (e *Engine) MessageReceived(p peer.ID, m bsmsg.BitSwapMessage) {
 		} else {
 			log.Debugf("wants %s - %d", entry.Cid, entry.Priority)
 			l.Wants(entry.Cid, entry.Priority)
-			blockSize, err := e.bs.GetSize(entry.Cid)
-			if err != nil {
-				if err == bstore.ErrNotFound {
-					continue
-				}
-				log.Error(err)
-			} else {
+			blockSize := blockSizes[entry.Cid]
+			if blockSize > 0 {
 				// we have the block
 				newWorkExists = true
 				if msgSize+blockSize > maxMessageSize {

--- a/decision/engine_test.go
+++ b/decision/engine_test.go
@@ -114,7 +114,7 @@ func TestConsistentAccounting(t *testing.T) {
 		m.AddBlock(blocks.NewBlock([]byte(strings.Join(content, " "))))
 
 		sender.Engine.MessageSent(receiver.Peer, m)
-		receiver.Engine.MessageReceived(sender.Peer, m)
+		receiver.Engine.MessageReceived(ctx, sender.Peer, m)
 	}
 
 	// Ensure sender records the change
@@ -144,7 +144,7 @@ func TestPeerIsAddedToPeersWhenMessageReceivedOrSent(t *testing.T) {
 	m := message.New(true)
 
 	sanfrancisco.Engine.MessageSent(seattle.Peer, m)
-	seattle.Engine.MessageReceived(sanfrancisco.Peer, m)
+	seattle.Engine.MessageReceived(ctx, sanfrancisco.Peer, m)
 
 	if seattle.Peer == sanfrancisco.Peer {
 		t.Fatal("Sanity Check: Peers have same Key!")
@@ -328,7 +328,7 @@ func partnerWants(e *Engine, keys []string, partner peer.ID) {
 		block := blocks.NewBlock([]byte(letter))
 		add.AddEntry(block.Cid(), len(keys)-i)
 	}
-	e.MessageReceived(partner, add)
+	e.MessageReceived(context.Background(), partner, add)
 }
 
 func partnerCancels(e *Engine, keys []string, partner peer.ID) {
@@ -337,7 +337,7 @@ func partnerCancels(e *Engine, keys []string, partner peer.ID) {
 		block := blocks.NewBlock([]byte(k))
 		cancels.Cancel(block.Cid())
 	}
-	e.MessageReceived(partner, cancels)
+	e.MessageReceived(context.Background(), partner, cancels)
 }
 
 func checkHandledInOrder(t *testing.T, e *Engine, expected [][]string) error {


### PR DESCRIPTION
Fixes https://github.com/ipfs/go-bitswap/issues/187

Combines experiments to improve read latency:
- [Parallelize request queue reads](https://github.com/ipfs/go-bitswap/pull/212)
  Use several engine task workers to pull requests off the request queue
- [Parallelize blockstore reads](https://github.com/ipfs/go-bitswap/pull/213)
  Use a pool of worker threads to read from the blockstore

See [results with simulated blockstore delay of 20ms](https://github.com/ipfs/go-bitswap/pull/215#issuecomment-545927131)