### PR TITLE
Dont hang outstanding jobs when blockstoreManager shuts down

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -374,7 +374,7 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg
 
 	// This call records changes to wantlists, blocks received,
 	// and number of bytes transfered.
-	bs.engine.MessageReceived(ctx, p, incoming)
+	bs.engine.MessageReceived(p, incoming)
 	// TODO: this is bad, and could be easily abused.
 	// Should only track *useful* messages in ledger
 

--- a/decision/blockstoremanager.go
+++ b/decision/blockstoremanager.go
@@ -1,7 +1,6 @@
 package decision
 
 import (
-	"context"
 	"fmt"
 	"sync"
 
@@ -23,7 +22,7 @@ var scheduleErr = fmt.Errorf("Could not schedule worker - blockstore manager shu
 
 // newBlockstoreManager creates a new blockstoreManager with the given context
 // and number of workers
-func newBlockstoreManager(ctx context.Context, bs bstore.Blockstore, workerCount int) *blockstoreManager {
+func newBlockstoreManager(bs bstore.Blockstore, workerCount int) *blockstoreManager {
 	return &blockstoreManager{
 		bs:          bs,
 		workerCount: workerCount,
@@ -66,24 +65,22 @@ func (bsm *blockstoreManager) shutdownWorker() {
 	}
 }
 
-func (bsm *blockstoreManager) addJob(ctx context.Context, job func(error)) {
+func (bsm *blockstoreManager) addJob(job func(error)) {
 	select {
-	case <-ctx.Done():
-		job(scheduleErr)
 	case <-bsm.px.Closing():
 		job(scheduleErr)
 	case bsm.jobs <- job:
 	}
 }
 
-func (bsm *blockstoreManager) getBlockSizes(ctx context.Context, ks []cid.Cid) map[cid.Cid]int {
+func (bsm *blockstoreManager) getBlockSizes(ks []cid.Cid) map[cid.Cid]int {
 	res := make(map[cid.Cid]int)
 	if len(ks) == 0 {
 		return res
 	}
 
 	var lk sync.Mutex
-	bsm.jobPerKey(ctx, ks, func(c cid.Cid) {
+	bsm.jobPerKey(ks, func(c cid.Cid) {
 		size, err := bsm.bs.GetSize(c)
 		if err != nil {
 			if err != bstore.ErrNotFound {
@@ -99,14 +96,14 @@ func (bsm *blockstoreManager) getBlockSizes(ctx context.Context, ks []cid.Cid) m
 	return res
 }
 
-func (bsm *blockstoreManager) getBlocks(ctx context.Context, ks []cid.Cid) map[cid.Cid]blocks.Block {
+func (bsm *blockstoreManager) getBlocks(ks []cid.Cid) map[cid.Cid]blocks.Block {
 	res := make(map[cid.Cid]blocks.Block)
 	if len(ks) == 0 {
 		return res
 	}
 
 	var lk sync.Mutex
-	bsm.jobPerKey(ctx, ks, func(c cid.Cid) {
+	bsm.jobPerKey(ks, func(c cid.Cid) {
 		blk, err := bsm.bs.Get(c)
 		if err != nil {
 			if err != bstore.ErrNotFound {
@@ -122,12 +119,12 @@ func (bsm *blockstoreManager) getBlocks(ctx context.Context, ks []cid.Cid) map[c
 	return res
 }
 
-func (bsm *blockstoreManager) jobPerKey(ctx context.Context, ks []cid.Cid, jobFn func(c cid.Cid)) {
+func (bsm *blockstoreManager) jobPerKey(ks []cid.Cid, jobFn func(c cid.Cid)) {
 	wg := sync.WaitGroup{}
 	for _, k := range ks {
 		c := k
 		wg.Add(1)
-		bsm.addJob(ctx, func(err error) {
+		bsm.addJob(func(err error) {
 			// Check if there was a scheduling error (because the manager was shut down)
 			if err == nil {
 				jobFn(c)

--- a/decision/engine_test.go
+++ b/decision/engine_test.go
@@ -114,7 +114,7 @@ func TestConsistentAccounting(t *testing.T) {
 		m.AddBlock(blocks.NewBlock([]byte(strings.Join(content, " "))))
 
 		sender.Engine.MessageSent(receiver.Peer, m)
-		receiver.Engine.MessageReceived(ctx, sender.Peer, m)
+		receiver.Engine.MessageReceived(sender.Peer, m)
 	}
 
 	// Ensure sender records the change
@@ -144,7 +144,7 @@ func TestPeerIsAddedToPeersWhenMessageReceivedOrSent(t *testing.T) {
 	m := message.New(true)
 
 	sanfrancisco.Engine.MessageSent(seattle.Peer, m)
-	seattle.Engine.MessageReceived(ctx, sanfrancisco.Peer, m)
+	seattle.Engine.MessageReceived(sanfrancisco.Peer, m)
 
 	if seattle.Peer == sanfrancisco.Peer {
 		t.Fatal("Sanity Check: Peers have same Key!")
@@ -328,7 +328,7 @@ func partnerWants(e *Engine, keys []string, partner peer.ID) {
 		block := blocks.NewBlock([]byte(letter))
 		add.AddEntry(block.Cid(), len(keys)-i)
 	}
-	e.MessageReceived(context.Background(), partner, add)
+	e.MessageReceived(partner, add)
 }
 
 func partnerCancels(e *Engine, keys []string, partner peer.ID) {
@@ -337,7 +337,7 @@ func partnerCancels(e *Engine, keys []string, partner peer.ID) {
 		block := blocks.NewBlock([]byte(k))
 		cancels.Cancel(block.Cid())
 	}
-	e.MessageReceived(context.Background(), partner, cancels)
+	e.MessageReceived(partner, cancels)
 }
 
 func checkHandledInOrder(t *testing.T, e *Engine, expected [][]string) error {


### PR DESCRIPTION
Fixes https://github.com/ipfs/go-bitswap/issues/237 by adding an `error` parameter to the job function. When the job is scheduled it first checks to see if there was a scheduling error before running.