### PR TITLE
Fix possible deadlock scenario in session want sender

### DIFF
--- a/internal/session/sessionwantsender.go
+++ b/internal/session/sessionwantsender.go
@@ -366,8 +366,12 @@ func (spm *sessionWantSender) processUpdates(updates []update) {
 
 	// If any peers have sent us too many consecutive DONT_HAVEs, remove them
 	// from the session
-	for p := range prunePeers {
-		spm.SignalAvailability(p, false)
+	if len(prunePeers) > 0 {
+		go func() {
+			for p := range prunePeers {
+				spm.SignalAvailability(p, false)
+			}
+		}()
 	}
 }
 


### PR DESCRIPTION
When a peer sends us several consecutive DONT_HAVEs, we remove it from the session by calling `spm.SignalAvailability(p, false)`.
However inside that method we add the update to a channel. If the channel is already full from other updates then the call will block, bringing the run loop to a deadlock.
The solution is to put the call inside a go routine. Peers sending several consecutive DONT_HAVEs is an infrequent enough scenario that it shouldn't be too expensive to use a go-routine here.