### PR TITLE
Simulate DONT_HAVE when peer doesn't respond to want-block (new peers)

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -125,7 +125,7 @@ func New(parent context.Context, network bsnet.BitSwapNetwork,
 	var wm *bswm.WantManager
 	// onDontHaveTimeout is called when a want-block is sent to a peer that
 	// has an old version of Bitswap that doesn't support DONT_HAVE messages,
-	// and no response is received within a timeout.
+	// or when no response is received within a timeout.
 	onDontHaveTimeout := func(p peer.ID, dontHaves []cid.Cid) {
 		// Simulate a DONT_HAVE message arriving to the WantManager
 		wm.ReceiveFrom(ctx, p, nil, nil, dontHaves)

--- a/internal/messagequeue/donthavetimeoutmgr.go
+++ b/internal/messagequeue/donthavetimeoutmgr.go
@@ -11,7 +11,8 @@ import (
 
 const (
 	// dontHaveTimeout is used to simulate a DONT_HAVE when communicating with
-	// a peer whose Bitswap client doesn't support the DONT_HAVE response.
+	// a peer whose Bitswap client doesn't support the DONT_HAVE response,
+	// or when the peer takes too long to respond.
 	// If the peer doesn't respond to a want-block within the timeout, the
 	// local node assumes that the peer doesn't have the block.
 	dontHaveTimeout = 5 * time.Second
@@ -45,7 +46,7 @@ type pendingWant struct {
 
 // dontHaveTimeoutMgr pings the peer to measure latency. It uses the latency to
 // set a reasonable timeout for simulating a DONT_HAVE message for peers that
-// don't support DONT_HAVE
+// don't support DONT_HAVE or that take to long to respond.
 type dontHaveTimeoutMgr struct {
 	ctx                        context.Context
 	shutdown                   func()

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -340,7 +340,7 @@ func (s *Session) broadcastWantHaves(ctx context.Context, wants []cid.Cid) {
 		// Search for providers who have the first want in the list.
 		// Typically if the provider has the first block they will have
 		// the rest of the blocks also.
-		log.Warnf("Ses%d: FindMorePeers with want %s (1st of %d wants)", s.id, lu.C(wants[0]), len(wants))
+		log.Infof("Ses%d: FindMorePeers with want %s (1st of %d wants)", s.id, lu.C(wants[0]), len(wants))
 		s.findMorePeers(ctx, wants[0])
 	}
 	s.resetIdleTick()


### PR DESCRIPTION
We should simulate a DONT_HAVE response when we send want-block to a peer and the peer doesn't respond within a reasonable amount of time.

We have this already for older peers (that don't support DONT_HAVE).
This PR adds support for newer peers (that do support DONT_HAVE).