### PR TITLE
feat: expose the full wantlist through GetWantlist

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -503,9 +503,15 @@ func (bs *Bitswap) Close() error {
 	return bs.process.Close()
 }
 
-// GetWantlist returns the current local wantlist.
+// GetWantlist returns the current local wantlist (both want-blocks and
+// want-haves).
 func (bs *Bitswap) GetWantlist() []cid.Cid {
 	return bs.pm.CurrentWants()
+}
+
+// GetWantBlocks returns the current list of want-blocks.
+func (bs *Bitswap) GetWantBlocks() []cid.Cid {
+	return bs.pm.CurrentWantBlocks()
 }
 
 // GetWanthaves returns the current list of want-haves.

--- a/internal/peermanager/peermanager.go
+++ b/internal/peermanager/peermanager.go
@@ -170,8 +170,16 @@ func (pm *PeerManager) SendCancels(ctx context.Context, cancelKs []cid.Cid) {
 	}
 }
 
-// CurrentWants returns the list of pending want-blocks
+// CurrentWants returns the list of pending wants (both want-haves and want-blocks).
 func (pm *PeerManager) CurrentWants() []cid.Cid {
+	pm.pqLk.RLock()
+	defer pm.pqLk.RUnlock()
+
+	return pm.pwm.GetWants()
+}
+
+// CurrentWantBlocks returns the list of pending want-blocks
+func (pm *PeerManager) CurrentWantBlocks() []cid.Cid {
 	pm.pqLk.RLock()
 	defer pm.pqLk.RUnlock()
 

--- a/internal/peermanager/peerwantmanager.go
+++ b/internal/peermanager/peerwantmanager.go
@@ -189,6 +189,28 @@ func (pwm *peerWantManager) GetWantHaves() []cid.Cid {
 	return res.Keys()
 }
 
+// GetWants returns the set of all wants (both want-blocks and want-haves).
+func (pwm *peerWantManager) GetWants() []cid.Cid {
+	res := cid.NewSet()
+
+	// Iterate over all known peers
+	for _, pws := range pwm.peerWants {
+		// Iterate over all want-blocks
+		for _, c := range pws.wantBlocks.Keys() {
+			// Add the CID to the results
+			res.Add(c)
+		}
+
+		// Iterate over all want-haves
+		for _, c := range pws.wantHaves.Keys() {
+			// Add the CID to the results
+			res.Add(c)
+		}
+	}
+
+	return res.Keys()
+}
+
 func (pwm *peerWantManager) String() string {
 	var b bytes.Buffer
 	for p, ws := range pwm.peerWants {


### PR DESCRIPTION
And expose a separate function for _just_ getting want-blocks. When the user runs `ipfs bitswap wantlist`, they expect to see everything the node is currently looking for.