### PR TITLE
Perf/message queue

### DIFF
--- a/internal/messagequeue/messagequeue_test.go
+++ b/internal/messagequeue/messagequeue_test.go
@@ -86,13 +86,13 @@ type fakeMessageSender struct {
 	sendError    error
 	fullClosed   chan<- struct{}
 	reset        chan<- struct{}
-	messagesSent chan<- bsmsg.BitSwapMessage
+	messagesSent chan<- []bsmsg.Entry
 	sendErrors   chan<- error
 	supportsHave bool
 }
 
 func newFakeMessageSender(sendError error, fullClosed chan<- struct{}, reset chan<- struct{},
-	messagesSent chan<- bsmsg.BitSwapMessage, sendErrors chan<- error, supportsHave bool) *fakeMessageSender {
+	messagesSent chan<- []bsmsg.Entry, sendErrors chan<- error, supportsHave bool) *fakeMessageSender {
 
 	return &fakeMessageSender{
 		sendError:    sendError,
@@ -112,7 +112,7 @@ func (fms *fakeMessageSender) SendMsg(ctx context.Context, msg bsmsg.BitSwapMess
 		fms.sendErrors <- fms.sendError
 		return fms.sendError
 	}
-	fms.messagesSent <- msg
+	fms.messagesSent <- msg.Wantlist()
 	return nil
 }
 func (fms *fakeMessageSender) clearSendError() {
@@ -129,9 +129,9 @@ func mockTimeoutCb(peer.ID, []cid.Cid) {}
 
 func collectMessages(ctx context.Context,
 	t *testing.T,
-	messagesSent <-chan bsmsg.BitSwapMessage,
-	timeout time.Duration) []bsmsg.BitSwapMessage {
-	var messagesReceived []bsmsg.BitSwapMessage
+	messagesSent <-chan []bsmsg.Entry,
+	timeout time.Duration) [][]bsmsg.Entry {
+	var messagesReceived [][]bsmsg.Entry
 	timeoutctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	for {
@@ -144,17 +144,17 @@ func collectMessages(ctx context.Context,
 	}
 }
 
-func totalEntriesLength(messages []bsmsg.BitSwapMessage) int {
+func totalEntriesLength(messages [][]bsmsg.Entry) int {
 	totalLength := 0
-	for _, messages := range messages {
-		totalLength += len(messages.Wantlist())
+	for _, m := range messages {
+		totalLength += len(m)
 	}
 	return totalLength
 }
 
 func TestStartupAndShutdown(t *testing.T) {
 	ctx := context.Background()
-	messagesSent := make(chan bsmsg.BitSwapMessage)
+	messagesSent := make(chan []bsmsg.Entry)
 	sendErrors := make(chan error)
 	resetChan := make(chan struct{}, 1)
 	fullClosedChan := make(chan struct{}, 1)
@@ -172,10 +172,10 @@ func TestStartupAndShutdown(t *testing.T) {
 	}
 
 	firstMessage := messages[0]
-	if len(firstMessage.Wantlist()) != len(bcstwh) {
+	if len(firstMessage) != len(bcstwh) {
 		t.Fatal("did not add all wants to want list")
 	}
-	for _, entry := range firstMessage.Wantlist() {
+	for _, entry := range firstMessage {
 		if entry.Cancel {
 			t.Fatal("initial add sent cancel entry when it should not have")
 		}
@@ -196,7 +196,7 @@ func TestStartupAndShutdown(t *testing.T) {
 
 func TestSendingMessagesDeduped(t *testing.T) {
 	ctx := context.Background()
-	messagesSent := make(chan bsmsg.BitSwapMessage)
+	messagesSent := make(chan []bsmsg.Entry)
 	sendErrors := make(chan error)
 	resetChan := make(chan struct{}, 1)
 	fullClosedChan := make(chan struct{}, 1)
@@ -219,7 +219,7 @@ func TestSendingMessagesDeduped(t *testing.T) {
 
 func TestSendingMessagesPartialDupe(t *testing.T) {
 	ctx := context.Background()
-	messagesSent := make(chan bsmsg.BitSwapMessage)
+	messagesSent := make(chan []bsmsg.Entry)
 	sendErrors := make(chan error)
 	resetChan := make(chan struct{}, 1)
 	fullClosedChan := make(chan struct{}, 1)
@@ -242,7 +242,7 @@ func TestSendingMessagesPartialDupe(t *testing.T) {
 
 func TestSendingMessagesPriority(t *testing.T) {
 	ctx := context.Background()
-	messagesSent := make(chan bsmsg.BitSwapMessage)
+	messagesSent := make(chan []bsmsg.Entry)
 	sendErrors := make(chan error)
 	resetChan := make(chan struct{}, 1)
 	fullClosedChan := make(chan struct{}, 1)
@@ -266,7 +266,7 @@ func TestSendingMessagesPriority(t *testing.T) {
 		t.Fatal("wrong number of wants")
 	}
 	byCid := make(map[cid.Cid]message.Entry)
-	for _, entry := range messages[0].Wantlist() {
+	for _, entry := range messages[0] {
 		byCid[entry.Cid] = entry
 	}
 
@@ -311,7 +311,7 @@ func TestSendingMessagesPriority(t *testing.T) {
 
 func TestCancelOverridesPendingWants(t *testing.T) {
 	ctx := context.Background()
-	messagesSent := make(chan bsmsg.BitSwapMessage)
+	messagesSent := make(chan []bsmsg.Entry)
 	sendErrors := make(chan error)
 	resetChan := make(chan struct{}, 1)
 	fullClosedChan := make(chan struct{}, 1)
@@ -331,7 +331,7 @@ func TestCancelOverridesPendingWants(t *testing.T) {
 		t.Fatal("Wrong message count")
 	}
 
-	wb, wh, cl := filterWantTypes(messages[0].Wantlist())
+	wb, wh, cl := filterWantTypes(messages[0])
 	if len(wb) != 1 || !wb[0].Equals(wantBlocks[1]) {
 		t.Fatal("Expected 1 want-block")
 	}
@@ -345,7 +345,7 @@ func TestCancelOverridesPendingWants(t *testing.T) {
 
 func TestWantOverridesPendingCancels(t *testing.T) {
 	ctx := context.Background()
-	messagesSent := make(chan bsmsg.BitSwapMessage)
+	messagesSent := make(chan []bsmsg.Entry)
 	sendErrors := make(chan error)
 	resetChan := make(chan struct{}, 1)
 	fullClosedChan := make(chan struct{}, 1)
@@ -364,7 +364,7 @@ func TestWantOverridesPendingCancels(t *testing.T) {
 		t.Fatal("Wrong message count")
 	}
 
-	wb, wh, cl := filterWantTypes(messages[0].Wantlist())
+	wb, wh, cl := filterWantTypes(messages[0])
 	if len(wb) != 1 || !wb[0].Equals(cancels[0]) {
 		t.Fatal("Expected 1 want-block")
 	}
@@ -378,7 +378,7 @@ func TestWantOverridesPendingCancels(t *testing.T) {
 
 func TestWantlistRebroadcast(t *testing.T) {
 	ctx := context.Background()
-	messagesSent := make(chan bsmsg.BitSwapMessage)
+	messagesSent := make(chan []bsmsg.Entry)
 	sendErrors := make(chan error)
 	resetChan := make(chan struct{}, 1)
 	fullClosedChan := make(chan struct{}, 1)
@@ -400,7 +400,7 @@ func TestWantlistRebroadcast(t *testing.T) {
 
 	// All broadcast want-haves should have been sent
 	firstMessage := messages[0]
-	if len(firstMessage.Wantlist()) != len(bcstwh) {
+	if len(firstMessage) != len(bcstwh) {
 		t.Fatal("wrong number of wants")
 	}
 
@@ -413,7 +413,7 @@ func TestWantlistRebroadcast(t *testing.T) {
 
 	// All the want-haves should have been rebroadcast
 	firstMessage = messages[0]
-	if len(firstMessage.Wantlist()) != len(bcstwh) {
+	if len(firstMessage) != len(bcstwh) {
 		t.Fatal("did not rebroadcast all wants")
 	}
 
@@ -429,7 +429,7 @@ func TestWantlistRebroadcast(t *testing.T) {
 
 	// All new wants should have been sent
 	firstMessage = messages[0]
-	if len(firstMessage.Wantlist()) != len(wantHaves)+len(wantBlocks) {
+	if len(firstMessage) != len(wantHaves)+len(wantBlocks) {
 		t.Fatal("wrong number of wants")
 	}
 
@@ -440,7 +440,7 @@ func TestWantlistRebroadcast(t *testing.T) {
 
 	// Both original and new wants should have been rebroadcast
 	totalWants := len(bcstwh) + len(wantHaves) + len(wantBlocks)
-	if len(firstMessage.Wantlist()) != totalWants {
+	if len(firstMessage) != totalWants {
 		t.Fatal("did not rebroadcast all wants")
 	}
 
@@ -455,10 +455,10 @@ func TestWantlistRebroadcast(t *testing.T) {
 
 	// Cancels for each want should have been sent
 	firstMessage = messages[0]
-	if len(firstMessage.Wantlist()) != len(cancels) {
+	if len(firstMessage) != len(cancels) {
 		t.Fatal("wrong number of cancels")
 	}
-	for _, entry := range firstMessage.Wantlist() {
+	for _, entry := range firstMessage {
 		if !entry.Cancel {
 			t.Fatal("expected cancels")
 		}
@@ -468,14 +468,14 @@ func TestWantlistRebroadcast(t *testing.T) {
 	messageQueue.SetRebroadcastInterval(10 * time.Millisecond)
 	messages = collectMessages(ctx, t, messagesSent, 15*time.Millisecond)
 	firstMessage = messages[0]
-	if len(firstMessage.Wantlist()) != totalWants-len(cancels) {
+	if len(firstMessage) != totalWants-len(cancels) {
 		t.Fatal("did not rebroadcast all wants")
 	}
 }
 
 func TestSendingLargeMessages(t *testing.T) {
 	ctx := context.Background()
-	messagesSent := make(chan bsmsg.BitSwapMessage)
+	messagesSent := make(chan []bsmsg.Entry)
 	sendErrors := make(chan error)
 	resetChan := make(chan struct{}, 1)
 	fullClosedChan := make(chan struct{}, 1)
@@ -506,7 +506,7 @@ func TestSendingLargeMessages(t *testing.T) {
 
 func TestSendToPeerThatDoesntSupportHave(t *testing.T) {
 	ctx := context.Background()
-	messagesSent := make(chan bsmsg.BitSwapMessage)
+	messagesSent := make(chan []bsmsg.Entry)
 	sendErrors := make(chan error)
 	resetChan := make(chan struct{}, 1)
 	fullClosedChan := make(chan struct{}, 1)
@@ -530,7 +530,7 @@ func TestSendToPeerThatDoesntSupportHave(t *testing.T) {
 	if len(messages) != 1 {
 		t.Fatal("wrong number of messages were sent", len(messages))
 	}
-	wl := messages[0].Wantlist()
+	wl := messages[0]
 	if len(wl) != len(bcwh) {
 		t.Fatal("wrong number of entries in wantlist", len(wl))
 	}
@@ -549,7 +549,7 @@ func TestSendToPeerThatDoesntSupportHave(t *testing.T) {
 	if len(messages) != 1 {
 		t.Fatal("wrong number of messages were sent", len(messages))
 	}
-	wl = messages[0].Wantlist()
+	wl = messages[0]
 	if len(wl) != len(wbs) {
 		t.Fatal("should only send want-blocks (no want-haves)", len(wl))
 	}
@@ -562,7 +562,7 @@ func TestSendToPeerThatDoesntSupportHave(t *testing.T) {
 
 func TestSendToPeerThatDoesntSupportHaveMonitorsTimeouts(t *testing.T) {
 	ctx := context.Background()
-	messagesSent := make(chan bsmsg.BitSwapMessage)
+	messagesSent := make(chan []bsmsg.Entry)
 	sendErrors := make(chan error)
 	resetChan := make(chan struct{}, 1)
 	fullClosedChan := make(chan struct{}, 1)
@@ -595,7 +595,7 @@ func TestSendToPeerThatDoesntSupportHaveMonitorsTimeouts(t *testing.T) {
 
 func TestResendAfterError(t *testing.T) {
 	ctx := context.Background()
-	messagesSent := make(chan bsmsg.BitSwapMessage)
+	messagesSent := make(chan []bsmsg.Entry)
 	sendErrors := make(chan error)
 	resetChan := make(chan struct{}, 1)
 	fullClosedChan := make(chan struct{}, 1)
@@ -634,7 +634,7 @@ func TestResendAfterError(t *testing.T) {
 
 func TestResendAfterMaxRetries(t *testing.T) {
 	ctx := context.Background()
-	messagesSent := make(chan bsmsg.BitSwapMessage)
+	messagesSent := make(chan []bsmsg.Entry)
 	sendErrors := make(chan error)
 	resetChan := make(chan struct{}, maxRetries*2)
 	fullClosedChan := make(chan struct{}, 1)
@@ -713,7 +713,7 @@ func BenchmarkMessageQueue(b *testing.B) {
 	ctx := context.Background()
 
 	createQueue := func() *MessageQueue {
-		messagesSent := make(chan bsmsg.BitSwapMessage)
+		messagesSent := make(chan []bsmsg.Entry)
 		sendErrors := make(chan error)
 		resetChan := make(chan struct{}, 1)
 		fullClosedChan := make(chan struct{}, 1)

--- a/message/message.go
+++ b/message/message.go
@@ -68,6 +68,9 @@ type BitSwapMessage interface {
 
 	// Reset the values in the message back to defaults, so it can be reused
 	Reset(bool)
+
+	// Clone the message fields
+	Clone() BitSwapMessage
 }
 
 // Exportable is an interface for structures than can be
@@ -130,11 +133,27 @@ func New(full bool) BitSwapMessage {
 
 func newMsg(full bool) *impl {
 	return &impl{
+		full:           full,
+		wantlist:       make(map[cid.Cid]*Entry),
 		blocks:         make(map[cid.Cid]blocks.Block),
 		blockPresences: make(map[cid.Cid]pb.Message_BlockPresenceType),
-		wantlist:       make(map[cid.Cid]*Entry),
-		full:           full,
 	}
+}
+
+// Clone the message fields
+func (m *impl) Clone() BitSwapMessage {
+	msg := newMsg(m.full)
+	for k := range m.wantlist {
+		msg.wantlist[k] = m.wantlist[k]
+	}
+	for k := range m.blocks {
+		msg.blocks[k] = m.blocks[k]
+	}
+	for k := range m.blockPresences {
+		msg.blockPresences[k] = m.blockPresences[k]
+	}
+	msg.pendingBytes = m.pendingBytes
+	return msg
 }
 
 // Reset the values in the message back to defaults, so it can be reused

--- a/message/message.go
+++ b/message/message.go
@@ -65,6 +65,9 @@ type BitSwapMessage interface {
 	Exportable
 
 	Loggable() map[string]interface{}
+
+	// Reset the values in the message back to defaults, so it can be reused
+	Reset(bool)
 }
 
 // Exportable is an interface for structures than can be
@@ -83,6 +86,33 @@ type Exportable interface {
 type BlockPresence struct {
 	Cid  cid.Cid
 	Type pb.Message_BlockPresenceType
+}
+
+// Entry is a wantlist entry in a Bitswap message, with flags indicating
+// - whether message is a cancel
+// - whether requester wants a DONT_HAVE message
+// - whether requester wants a HAVE message (instead of the block)
+type Entry struct {
+	wantlist.Entry
+	Cancel       bool
+	SendDontHave bool
+}
+
+// Get the size of the entry on the wire
+func (e *Entry) Size() int {
+	epb := e.ToPB()
+	return epb.Size()
+}
+
+// Get the entry in protobuf form
+func (e *Entry) ToPB() pb.Message_Wantlist_Entry {
+	return pb.Message_Wantlist_Entry{
+		Block:        pb.Cid{Cid: e.Cid},
+		Priority:     int32(e.Priority),
+		Cancel:       e.Cancel,
+		WantType:     e.WantType,
+		SendDontHave: e.SendDontHave,
+	}
 }
 
 type impl struct {
@@ -107,14 +137,19 @@ func newMsg(full bool) *impl {
 	}
 }
 
-// Entry is a wantlist entry in a Bitswap message, with flags indicating
-// - whether message is a cancel
-// - whether requester wants a DONT_HAVE message
-// - whether requester wants a HAVE message (instead of the block)
-type Entry struct {
-	wantlist.Entry
-	Cancel       bool
-	SendDontHave bool
+// Reset the values in the message back to defaults, so it can be reused
+func (m *impl) Reset(full bool) {
+	m.full = full
+	for k := range m.wantlist {
+		delete(m.wantlist, k)
+	}
+	for k := range m.blocks {
+		delete(m.blocks, k)
+	}
+	for k := range m.blockPresences {
+		delete(m.blockPresences, k)
+	}
+	m.pendingBytes = 0
 }
 
 var errCidMissing = errors.New("missing cid")
@@ -267,8 +302,7 @@ func (m *impl) addEntry(c cid.Cid, priority int32, cancel bool, wantType pb.Mess
 	}
 	m.wantlist[c] = e
 
-	aspb := entryToPB(e)
-	return aspb.Size()
+	return e.Size()
 }
 
 func (m *impl) AddBlock(b blocks.Block) {
@@ -300,8 +334,7 @@ func (m *impl) Size() int {
 		size += BlockPresenceSize(c)
 	}
 	for _, e := range m.wantlist {
-		epb := entryToPB(e)
-		size += epb.Size()
+		size += e.Size()
 	}
 
 	return size
@@ -337,21 +370,11 @@ func FromMsgReader(r msgio.Reader) (BitSwapMessage, error) {
 	return newMessageFromProto(pb)
 }
 
-func entryToPB(e *Entry) pb.Message_Wantlist_Entry {
-	return pb.Message_Wantlist_Entry{
-		Block:        pb.Cid{Cid: e.Cid},
-		Priority:     int32(e.Priority),
-		Cancel:       e.Cancel,
-		WantType:     e.WantType,
-		SendDontHave: e.SendDontHave,
-	}
-}
-
 func (m *impl) ToProtoV0() *pb.Message {
 	pbm := new(pb.Message)
 	pbm.Wantlist.Entries = make([]pb.Message_Wantlist_Entry, 0, len(m.wantlist))
 	for _, e := range m.wantlist {
-		pbm.Wantlist.Entries = append(pbm.Wantlist.Entries, entryToPB(e))
+		pbm.Wantlist.Entries = append(pbm.Wantlist.Entries, e.ToPB())
 	}
 	pbm.Wantlist.Full = m.full
 
@@ -367,7 +390,7 @@ func (m *impl) ToProtoV1() *pb.Message {
 	pbm := new(pb.Message)
 	pbm.Wantlist.Entries = make([]pb.Message_Wantlist_Entry, 0, len(m.wantlist))
 	for _, e := range m.wantlist {
-		pbm.Wantlist.Entries = append(pbm.Wantlist.Entries, entryToPB(e))
+		pbm.Wantlist.Entries = append(pbm.Wantlist.Entries, e.ToPB())
 	}
 	pbm.Wantlist.Full = m.full
 

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -2,7 +2,6 @@ package message
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	pb "github.com/ipfs/go-bitswap/message/pb"
@@ -305,8 +304,6 @@ func TestEntrySize(t *testing.T) {
 		SendDontHave: true,
 		Cancel:       false,
 	}
-	fmt.Println(len(c.Bytes()))
-	fmt.Println(len(c.KeyString()))
 	epb := e.ToPB()
 	if e.Size() != epb.Size() {
 		t.Fatal("entry size calculation incorrect", e.Size(), epb.Size())

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -2,9 +2,12 @@ package message
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	pb "github.com/ipfs/go-bitswap/message/pb"
+	"github.com/ipfs/go-bitswap/wantlist"
+	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
 
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
@@ -287,5 +290,25 @@ func TestAddWantlistEntry(t *testing.T) {
 	msg.AddEntry(b.Cid(), 10, pb.Message_Wantlist_Block, true)
 	if !e.Cancel {
 		t.Fatal("want should not override cancel")
+	}
+}
+
+func TestEntrySize(t *testing.T) {
+	blockGenerator := blocksutil.NewBlockGenerator()
+	c := blockGenerator.Next().Cid()
+	e := Entry{
+		Entry: wantlist.Entry{
+			Cid:      c,
+			Priority: 10,
+			WantType: pb.Message_Wantlist_Have,
+		},
+		SendDontHave: true,
+		Cancel:       false,
+	}
+	fmt.Println(len(c.Bytes()))
+	fmt.Println(len(c.KeyString()))
+	epb := e.ToPB()
+	if e.Size() != epb.Size() {
+		t.Fatal("entry size calculation incorrect", e.Size(), epb.Size())
 	}
 }

--- a/testnet/virtual.go
+++ b/testnet/virtual.go
@@ -128,6 +128,8 @@ func (n *network) SendMessage(
 	to peer.ID,
 	mes bsmsg.BitSwapMessage) error {
 
+	mes = mes.Clone()
+
 	n.mu.Lock()
 	defer n.mu.Unlock()
 


### PR DESCRIPTION
Fixes https://github.com/ipfs/go-bitswap/issues/306

`go test -run=XXX -benchtime=20s -bench=. -cpuprofile prof.out`

#### Creating a new message

Old:
```
         .          .    493:	// Create a new message
         .      740ms    494:	msg := bsmsg.New(false)
```

New:
```
         .          .    410:	// After processing the message, clear out its fields to save memory
         .          .    411:	defer mq.msg.Reset(false)
```

#### Adding an entry to the message

Old:
```
         .      480ms    518:		msgSize += msg.AddEntry(e.Cid, e.Priority, wantType, false)
```

New:
```
         .      260ms    528:		msgSize += mq.msg.AddEntry(e.Cid, e.Priority, wantType, false)
```

#### Getting the wantlist

Old:
```
         .      1.39s    551:		for _, e := range msg.Wantlist() {
```

Seems a little faster, but I think things may just have moved around. In any case we're calling it once now instead of twice:
New:
```
         .      220ms    417:	wantlist := message.Wantlist()
```
