### PR TITLE
fix: avoid goroutine when receiving an error

### DIFF
--- a/network/ipfs_impl.go
+++ b/network/ipfs_impl.go
@@ -259,7 +259,7 @@ func (bsnet *impl) handleNewStream(s network.Stream) {
 		if err != nil {
 			if err != io.EOF {
 				_ = s.Reset()
-				go bsnet.receiver.ReceiveError(err)
+				bsnet.receiver.ReceiveError(err)
 				log.Debugf("bitswap net handleNewStream from %s error: %s", s.Conn().RemotePeer(), err)
 			}
 			return


### PR DESCRIPTION
There's no reason to launch this async.