### PR TITLE
fix: minimize time holding wantlist lock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/libp2p/go-libp2p-testing v0.1.1
 	github.com/libp2p/go-msgio v0.0.4
 	github.com/multiformats/go-multiaddr v0.2.1
+	github.com/multiformats/go-multistream v0.1.1
 	go.uber.org/zap v1.14.1
 )
 

--- a/internal/decision/engine.go
+++ b/internal/decision/engine.go
@@ -337,9 +337,13 @@ func (e *Engine) onPeerRemoved(p peer.ID) {
 // WantlistForPeer returns the currently understood want list for a given peer
 func (e *Engine) WantlistForPeer(p peer.ID) (out []wl.Entry) {
 	partner := e.findOrCreate(p)
+
 	partner.lk.Lock()
-	defer partner.lk.Unlock()
-	return partner.wantList.SortedEntries()
+	entries := partner.wantList.Entries()
+	partner.lk.Unlock()
+
+	wl.SortEntries(entries)
+	return
 }
 
 // LedgerForPeer returns aggregated data about blocks swapped and communication

--- a/message/message.go
+++ b/message/message.go
@@ -44,6 +44,10 @@ type BitSwapMessage interface {
 	// Returns the size of the CANCEL entry in the protobuf
 	Cancel(key cid.Cid) int
 
+	// Remove removes any entries for the given CID. Useful when the want
+	// status for the CID changes when preparing a message.
+	Remove(key cid.Cid)
+
 	// Empty indicates whether the message has any information
 	Empty() bool
 	// Size returns the size of the message in bytes
@@ -296,6 +300,10 @@ func (m *impl) PendingBytes() int32 {
 
 func (m *impl) SetPendingBytes(pendingBytes int32) {
 	m.pendingBytes = pendingBytes
+}
+
+func (m *impl) Remove(k cid.Cid) {
+	delete(m.wantlist, k)
 }
 
 func (m *impl) Cancel(k cid.Cid) int {

--- a/wantlist/wantlist.go
+++ b/wantlist/wantlist.go
@@ -111,16 +111,14 @@ func (w *Wantlist) Entries() []Entry {
 	return es
 }
 
-// SortedEntries returns wantlist entries ordered by priority.
-func (w *Wantlist) SortedEntries() []Entry {
-	es := w.Entries()
-	sort.Sort(entrySlice(es))
-	return es
-}
-
 // Absorb all the entries in other into this want list
 func (w *Wantlist) Absorb(other *Wantlist) {
 	for _, e := range other.Entries() {
 		w.Add(e.Cid, e.Priority, e.WantType)
 	}
+}
+
+// SortEntries sorts the list of entries by priority.
+func SortEntries(es []Entry) {
+	sort.Sort(entrySlice(es))
 }

--- a/wantlist/wantlist_test.go
+++ b/wantlist/wantlist_test.go
@@ -203,14 +203,16 @@ func TestAbsort(t *testing.T) {
 	}
 }
 
-func TestSortedEntries(t *testing.T) {
+func TestSortEntries(t *testing.T) {
 	wl := New()
 
 	wl.Add(testcids[0], 3, pb.Message_Wantlist_Block)
 	wl.Add(testcids[1], 5, pb.Message_Wantlist_Have)
 	wl.Add(testcids[2], 4, pb.Message_Wantlist_Have)
 
-	entries := wl.SortedEntries()
+	entries := wl.Entries()
+	SortEntries(entries)
+
 	if !entries[0].Cid.Equals(testcids[1]) ||
 		!entries[1].Cid.Equals(testcids[2]) ||
 		!entries[2].Cid.Equals(testcids[0]) {


### PR DESCRIPTION
Instead of holding the lock the entire time we prepare a message, hold the lock while we retrieve the wantlist entries, process the entries without the lock, retake the lock, then mark entries as sent.

This means:

1. We never sort entries while holding the lock.
2. We allocate exactly three times while holding the lock (once per entry list).

This change also tries to be as lazy as possible when sorting.