### PR TITLE
feat: move broadcast wantlist into the peermanager

### DIFF
--- a/internal/messagequeue/messagequeue.go
+++ b/internal/messagequeue/messagequeue.go
@@ -261,7 +261,6 @@ func (mq *MessageQueue) AddCancels(cancelKs []cid.Cid) {
 	mq.dhTimeoutMgr.CancelPending(cancelKs)
 
 	mq.wllock.Lock()
-	defer mq.wllock.Unlock()
 
 	workReady := false
 
@@ -281,6 +280,10 @@ func (mq *MessageQueue) AddCancels(cancelKs []cid.Cid) {
 			workReady = true
 		}
 	}
+
+	mq.wllock.Unlock()
+
+	// Unlock first to be nice to the scheduler.
 
 	// Schedule a message send
 	if workReady {

--- a/internal/peermanager/peermanager.go
+++ b/internal/peermanager/peermanager.go
@@ -82,18 +82,16 @@ func (pm *PeerManager) ConnectedPeers() []peer.ID {
 
 // Connected is called to add a new peer to the pool, and send it an initial set
 // of wants.
-func (pm *PeerManager) Connected(p peer.ID, initialWantHaves []cid.Cid) {
+func (pm *PeerManager) Connected(p peer.ID) {
 	pm.pqLk.Lock()
 	defer pm.pqLk.Unlock()
 
 	pq := pm.getOrCreate(p)
 
 	// Inform the peer want manager that there's a new peer
-	pm.pwm.addPeer(p)
-	// Record that the want-haves are being sent to the peer
-	_, wantHaves := pm.pwm.prepareSendWants(p, nil, initialWantHaves)
+	wants := pm.pwm.addPeer(p)
 	// Broadcast any live want-haves to the newly connected peers
-	pq.AddBroadcastWantHaves(wantHaves)
+	pq.AddBroadcastWantHaves(wants)
 	// Inform the sessions that the peer has connected
 	pm.signalAvailability(p, true)
 }

--- a/internal/peermanager/peerwantmanager.go
+++ b/internal/peermanager/peerwantmanager.go
@@ -70,7 +70,7 @@ func (pwm *peerWantManager) removePeer(p peer.ID) {
 		return
 	}
 
-	pws.wantBlocks.ForEach(func(c cid.Cid) error {
+	_ = pws.wantBlocks.ForEach(func(c cid.Cid) error {
 		// Decrement the gauge by the number of pending want-blocks to the peer
 		pwm.wantBlockGauge.Dec()
 		// Clean up want-blocks from the reverse index
@@ -79,7 +79,7 @@ func (pwm *peerWantManager) removePeer(p peer.ID) {
 	})
 
 	// Clean up want-haves from the reverse index
-	pws.wantHaves.ForEach(func(c cid.Cid) error {
+	_ = pws.wantHaves.ForEach(func(c cid.Cid) error {
 		pwm.reverseIndexRemove(c, p)
 		return nil
 	})
@@ -298,7 +298,7 @@ func (pwm *peerWantManager) getWantBlocks() []cid.Cid {
 	// Iterate over all known peers
 	for _, pws := range pwm.peerWants {
 		// Iterate over all want-blocks
-		pws.wantBlocks.ForEach(func(c cid.Cid) error {
+		_ = pws.wantBlocks.ForEach(func(c cid.Cid) error {
 			// Add the CID to the results
 			res.Add(c)
 			return nil
@@ -315,13 +315,13 @@ func (pwm *peerWantManager) getWantHaves() []cid.Cid {
 	// Iterate over all peers with active wants.
 	for _, pws := range pwm.peerWants {
 		// Iterate over all want-haves
-		pws.wantHaves.ForEach(func(c cid.Cid) error {
+		_ = pws.wantHaves.ForEach(func(c cid.Cid) error {
 			// Add the CID to the results
 			res.Add(c)
 			return nil
 		})
 	}
-	pwm.broadcastWants.ForEach(func(c cid.Cid) error {
+	_ = pwm.broadcastWants.ForEach(func(c cid.Cid) error {
 		res.Add(c)
 		return nil
 	})

--- a/internal/peermanager/peerwantmanager_test.go
+++ b/internal/peermanager/peerwantmanager_test.go
@@ -38,8 +38,12 @@ func TestPrepareBroadcastWantHaves(t *testing.T) {
 	cids2 := testutil.GenerateCids(2)
 	cids3 := testutil.GenerateCids(2)
 
-	pwm.addPeer(peers[0])
-	pwm.addPeer(peers[1])
+	if blist := pwm.addPeer(peers[0]); len(blist) > 0 {
+		t.Errorf("expected no broadcast wants")
+	}
+	if blist := pwm.addPeer(peers[1]); len(blist) > 0 {
+		t.Errorf("expected no broadcast wants")
+	}
 
 	// Broadcast 2 cids to 2 peers
 	bcst := pwm.prepareBroadcastWantHaves(cids)
@@ -104,16 +108,19 @@ func TestPrepareBroadcastWantHaves(t *testing.T) {
 		}
 	}
 
+	allCids := cids
+	allCids = append(allCids, cids2...)
+	allCids = append(allCids, cids3...)
+	allCids = append(allCids, cids4...)
+
 	// Add another peer
-	pwm.addPeer(peers[2])
-	bcst6 := pwm.prepareBroadcastWantHaves(cids)
-	if len(bcst6) != 1 {
-		t.Fatal("Expected 1 peer")
+	bcst6 := pwm.addPeer(peers[2])
+	if !testutil.MatchKeysIgnoreOrder(bcst6, allCids) {
+		t.Fatalf("Expected all cids to be broadcast.")
 	}
-	for p := range bcst6 {
-		if !testutil.MatchKeysIgnoreOrder(bcst6[p], cids) {
-			t.Fatal("Expected all cids to be broadcast")
-		}
+
+	if broadcast := pwm.prepareBroadcastWantHaves(allCids); len(broadcast) != 0 {
+		t.Errorf("did not expect to have CIDs to broadcast")
 	}
 }
 


### PR DESCRIPTION
This deduplicates some state and allows us to do less book-keeping for broadcast wants. We should probably rename the PeerManager to the WantManager and rename the WantManager to something else. It no longer manages _any_ wants.