### PR TITLE
Change timing for DONT_HAVE timeouts to be more conservative

### DIFF
--- a/internal/messagequeue/donthavetimeoutmgr.go
+++ b/internal/messagequeue/donthavetimeoutmgr.go
@@ -19,12 +19,12 @@ const (
 
 	// maxExpectedWantProcessTime is the maximum amount of time we expect a
 	// peer takes to process a want and initiate sending a response to us
-	maxExpectedWantProcessTime = 200 * time.Millisecond
+	maxExpectedWantProcessTime = 2 * time.Second
 
 	// latencyMultiplier is multiplied by the average ping time to
 	// get an upper bound on how long we expect to wait for a peer's response
 	// to arrive
-	latencyMultiplier = 2
+	latencyMultiplier = 3
 )
 
 // PeerConnection is a connection to a peer that can be pinged, and the


### PR DESCRIPTION
Ideally we would actually measure how long it takes between sending a want and receiving a response, but this will solve the immediate problem of too many dups