### PR TITLE
Total wants gauge

### DIFF
--- a/internal/peermanager/peermanager.go
+++ b/internal/peermanager/peermanager.go
@@ -52,9 +52,10 @@ type PeerManager struct {
 // New creates a new PeerManager, given a context and a peerQueueFactory.
 func New(ctx context.Context, createPeerQueue PeerQueueFactory, self peer.ID) *PeerManager {
 	wantGauge := metrics.NewCtx(ctx, "wantlist_total", "Number of items in wantlist.").Gauge()
+	wantBlockGauge := metrics.NewCtx(ctx, "want_blocks_total", "Number of want-blocks in wantlist.").Gauge()
 	return &PeerManager{
 		peerQueues:      make(map[peer.ID]PeerQueue),
-		pwm:             newPeerWantManager(wantGauge),
+		pwm:             newPeerWantManager(wantGauge, wantBlockGauge),
 		createPeerQueue: createPeerQueue,
 		ctx:             ctx,
 		self:            self,

--- a/internal/peermanager/peerwantmanager.go
+++ b/internal/peermanager/peerwantmanager.go
@@ -71,11 +71,6 @@ func (pwm *peerWantManager) addPeer(peerQueue PeerQueue, p peer.ID) {
 	if pwm.broadcastWants.Len() > 0 {
 		wants := pwm.broadcastWants.Keys()
 		peerQueue.AddBroadcastWantHaves(wants)
-
-		// Increment want gauge
-		for range wants {
-			pwm.wantGauge.Inc()
-		}
 	}
 }
 
@@ -86,28 +81,31 @@ func (pwm *peerWantManager) removePeer(p peer.ID) {
 		return
 	}
 
+	// Clean up want-blocks
 	_ = pws.wantBlocks.ForEach(func(c cid.Cid) error {
-		// Decrement the gauges by the number of pending want-blocks to the peer
-		pwm.wantGauge.Dec()
-		pwm.wantBlockGauge.Dec()
 		// Clean up want-blocks from the reverse index
-		pwm.reverseIndexRemove(c, p)
+		removedLastPeer := pwm.reverseIndexRemove(c, p)
+
+		// Decrement the gauges by the number of pending want-blocks to the peer
+		if removedLastPeer {
+			if !pwm.broadcastWants.Has(c) {
+				pwm.wantGauge.Dec()
+				pwm.wantBlockGauge.Dec()
+			}
+		}
 		return nil
 	})
 
-	// Clean up want-haves from the reverse index
+	// Clean up want-haves
 	_ = pws.wantHaves.ForEach(func(c cid.Cid) error {
-		// Decrement the gauge by the number of pending want-haves to the peer
-		pwm.wantGauge.Dec()
 		// Clean up want-haves from the reverse index
-		pwm.reverseIndexRemove(c, p)
-		return nil
-	})
+		removedLastPeer := pwm.reverseIndexRemove(c, p)
 
-	// Decrement total wants gauge for each broadcast want
-	_ = pwm.broadcastWants.ForEach(func(c cid.Cid) error {
-		if !pws.wantBlocks.Has(c) && !pws.wantHaves.Has(c) {
-			pwm.wantGauge.Dec()
+		// Decrement the gauge by the number of pending want-haves to the peer
+		if removedLastPeer {
+			if !pwm.broadcastWants.Has(c) {
+				pwm.wantGauge.Dec()
+			}
 		}
 		return nil
 	})
@@ -125,6 +123,11 @@ func (pwm *peerWantManager) broadcastWantHaves(wantHaves []cid.Cid) {
 		}
 		pwm.broadcastWants.Add(c)
 		unsent = append(unsent, c)
+
+		// Increment the total wants gauge
+		if _, ok := pwm.wantPeers[c]; !ok {
+			pwm.wantGauge.Inc()
+		}
 	}
 
 	if len(unsent) == 0 {
@@ -146,11 +149,6 @@ func (pwm *peerWantManager) broadcastWantHaves(wantHaves []cid.Cid) {
 
 		if len(peerUnsent) > 0 {
 			pws.peerQueue.AddBroadcastWantHaves(peerUnsent)
-		}
-
-		// Increment the total wants gauge
-		for range peerUnsent {
-			pwm.wantGauge.Inc()
 		}
 	}
 }
@@ -176,18 +174,22 @@ func (pwm *peerWantManager) sendWants(p peer.ID, wantBlocks []cid.Cid, wantHaves
 			// Record that the CID was sent as a want-block
 			pws.wantBlocks.Add(c)
 
-			// Update the reverse index
-			pwm.reverseIndexAdd(c, p)
-
 			// Add the CID to the results
 			fltWantBlks = append(fltWantBlks, c)
 
 			// Make sure the CID is no longer recorded as a want-have
 			pws.wantHaves.Remove(c)
 
+			// Update the reverse index
+			isNew := pwm.reverseIndexAdd(c, p)
+
 			// Increment the want gauges
-			pwm.wantGauge.Inc()
-			pwm.wantBlockGauge.Inc()
+			if isNew {
+				pwm.wantBlockGauge.Inc()
+				if !pwm.broadcastWants.Has(c) {
+					pwm.wantGauge.Inc()
+				}
+			}
 		}
 	}
 
@@ -204,14 +206,18 @@ func (pwm *peerWantManager) sendWants(p peer.ID, wantBlocks []cid.Cid, wantHaves
 			// Record that the CID was sent as a want-have
 			pws.wantHaves.Add(c)
 
-			// Update the reverse index
-			pwm.reverseIndexAdd(c, p)
-
 			// Add the CID to the results
 			fltWantHvs = append(fltWantHvs, c)
 
+			// Update the reverse index
+			isNew := pwm.reverseIndexAdd(c, p)
+
 			// Increment the total wants gauge
-			pwm.wantGauge.Inc()
+			if isNew {
+				if !pwm.broadcastWants.Has(c) {
+					pwm.wantGauge.Inc()
+				}
+			}
 		}
 	}
 
@@ -236,6 +242,9 @@ func (pwm *peerWantManager) sendCancels(cancelKs []cid.Cid) {
 		}
 	}
 
+	cancelledWantBlocks := cid.NewSet()
+	cancelledWantHaves := cid.NewSet()
+
 	// Send cancels to a particular peer
 	send := func(p peer.ID, pws *peerWant) {
 		// Start from the broadcast cancels
@@ -245,13 +254,15 @@ func (pwm *peerWantManager) sendCancels(cancelKs []cid.Cid) {
 		for _, c := range cancelKs {
 			// Check if a want was sent for the key
 			wantBlock := pws.wantBlocks.Has(c)
-			if !wantBlock && !pws.wantHaves.Has(c) {
-				continue
-			}
+			wantHave := pws.wantHaves.Has(c)
 
-			// Update the want gauge
+			// Update the want gauges
 			if wantBlock {
-				pwm.wantBlockGauge.Dec()
+				cancelledWantBlocks.Add(c)
+			} else if wantHave {
+				cancelledWantHaves.Add(c)
+			} else {
+				continue
 			}
 
 			// Unconditionally remove from the want lists.
@@ -268,11 +279,6 @@ func (pwm *peerWantManager) sendCancels(cancelKs []cid.Cid) {
 		// Send cancels to the peer
 		if len(toCancel) > 0 {
 			pws.peerQueue.AddCancels(toCancel)
-		}
-
-		// Decrement the total wants gauge
-		for range toCancel {
-			pwm.wantGauge.Dec()
 		}
 	}
 
@@ -305,33 +311,54 @@ func (pwm *peerWantManager) sendCancels(cancelKs []cid.Cid) {
 	// Remove cancelled broadcast wants
 	for _, c := range broadcastCancels {
 		pwm.broadcastWants.Remove(c)
+
+		// Decrement the total wants gauge for broadcast wants
+		if !cancelledWantHaves.Has(c) && !cancelledWantBlocks.Has(c) {
+			pwm.wantGauge.Dec()
+		}
 	}
+
+	// Decrement the total wants gauge for peer wants
+	_ = cancelledWantHaves.ForEach(func(c cid.Cid) error {
+		pwm.wantGauge.Dec()
+		return nil
+	})
+	_ = cancelledWantBlocks.ForEach(func(c cid.Cid) error {
+		pwm.wantGauge.Dec()
+		pwm.wantBlockGauge.Dec()
+		return nil
+	})
 
 	// Finally, batch-remove the reverse-index. There's no need to
 	// clear this index peer-by-peer.
 	for _, c := range cancelKs {
 		delete(pwm.wantPeers, c)
 	}
+
 }
 
 // Add the peer to the list of peers that have sent a want with the cid
-func (pwm *peerWantManager) reverseIndexAdd(c cid.Cid, p peer.ID) {
+func (pwm *peerWantManager) reverseIndexAdd(c cid.Cid, p peer.ID) bool {
 	peers, ok := pwm.wantPeers[c]
 	if !ok {
 		peers = make(map[peer.ID]struct{}, 10)
 		pwm.wantPeers[c] = peers
 	}
 	peers[p] = struct{}{}
+	return !ok
 }
 
 // Remove the peer from the list of peers that have sent a want with the cid
-func (pwm *peerWantManager) reverseIndexRemove(c cid.Cid, p peer.ID) {
+func (pwm *peerWantManager) reverseIndexRemove(c cid.Cid, p peer.ID) bool {
 	if peers, ok := pwm.wantPeers[c]; ok {
 		delete(peers, p)
 		if len(peers) == 0 {
 			delete(pwm.wantPeers, c)
+			return true
 		}
 	}
+
+	return false
 }
 
 // GetWantBlocks returns the set of all want-blocks sent to all peers

--- a/internal/peermanager/peerwantmanager.go
+++ b/internal/peermanager/peerwantmanager.go
@@ -102,10 +102,8 @@ func (pwm *peerWantManager) removePeer(p peer.ID) {
 		removedLastPeer := pwm.reverseIndexRemove(c, p)
 
 		// Decrement the gauge by the number of pending want-haves to the peer
-		if removedLastPeer {
-			if !pwm.broadcastWants.Has(c) {
-				pwm.wantGauge.Dec()
-			}
+		if removedLastPeer && !pwm.broadcastWants.Has(c) {
+			pwm.wantGauge.Dec()
 		}
 		return nil
 	})
@@ -213,10 +211,8 @@ func (pwm *peerWantManager) sendWants(p peer.ID, wantBlocks []cid.Cid, wantHaves
 			isNew := pwm.reverseIndexAdd(c, p)
 
 			// Increment the total wants gauge
-			if isNew {
-				if !pwm.broadcastWants.Has(c) {
-					pwm.wantGauge.Inc()
-				}
+			if isNew && !pwm.broadcastWants.Has(c) {
+				pwm.wantGauge.Inc()
 			}
 		}
 	}

--- a/internal/peermanager/peerwantmanager.go
+++ b/internal/peermanager/peerwantmanager.go
@@ -88,9 +88,9 @@ func (pwm *peerWantManager) removePeer(p peer.ID) {
 
 		// Decrement the gauges by the number of pending want-blocks to the peer
 		if removedLastPeer {
+			pwm.wantBlockGauge.Dec()
 			if !pwm.broadcastWants.Has(c) {
 				pwm.wantGauge.Dec()
-				pwm.wantBlockGauge.Dec()
 			}
 		}
 		return nil

--- a/internal/peermanager/peerwantmanager_test.go
+++ b/internal/peermanager/peerwantmanager_test.go
@@ -386,9 +386,8 @@ func TestStats(t *testing.T) {
 	// Add a second peer
 	pwm.addPeer(pq, p1)
 
-	// Expect all broadcast want-haves to be sent to the new peer
-	if g.count != 11 {
-		t.Fatal("Expected 11 wants")
+	if g.count != 8 {
+		t.Fatal("Expected 8 wants")
 	}
 	if wbg.count != 4 {
 		t.Fatal("Expected 4 want-blocks")
@@ -399,8 +398,8 @@ func TestStats(t *testing.T) {
 	cids5 := testutil.GenerateCids(1)
 	pwm.sendCancels(append(cids5, cids[0]))
 
-	if g.count != 10 {
-		t.Fatal("Expected 10 wants")
+	if g.count != 7 {
+		t.Fatal("Expected 7 wants")
 	}
 	if wbg.count != 3 {
 		t.Fatal("Expected 3 want-blocks")
@@ -408,19 +407,32 @@ func TestStats(t *testing.T) {
 
 	// Remove first peer
 	pwm.removePeer(p0)
+
+	// Should still have 3 broadcast wants
 	if g.count != 3 {
 		t.Fatal("Expected 3 wants")
 	}
 	if wbg.count != 0 {
-		t.Fatal("Expected all want-blocks to be removed with peer")
+		t.Fatal("Expected all want-blocks to be removed")
 	}
 
 	// Remove second peer
 	pwm.removePeer(p1)
-	if g.count != 0 {
-		t.Fatal("Expected all wants to be removed")
+
+	// Should still have 3 broadcast wants
+	if g.count != 3 {
+		t.Fatal("Expected 3 wants")
 	}
 	if wbg.count != 0 {
-		t.Fatal("Expected all wants to be removed")
+		t.Fatal("Expected 0 want-blocks")
+	}
+
+	// Cancel one remaining broadcast want-have
+	pwm.sendCancels(cids2[:1])
+	if g.count != 2 {
+		t.Fatal("Expected 2 wants")
+	}
+	if wbg.count != 0 {
+		t.Fatal("Expected 0 want-blocks")
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/ipfs/go-bitswap/issues/333

Currently we track the number of pending want-blocks in `wantlist_total`.

In this PR
- `wantlist_total` is the total number of pending want-blocks + want-haves
- `want_blocks_total` is the total number of pending want-blocks