### PR TITLE
If peer is first to send a block to session, protect connection

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -65,6 +65,8 @@ type SessionPeerManager interface {
 	Peers() []peer.ID
 	// Whether there are any peers in the session
 	HasPeers() bool
+	// Protect connection from being pruned by the connection manager
+	ProtectConnection(peer.ID)
 }
 
 // ProviderFinder is used to find providers for a given key

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -56,16 +56,42 @@ func newFakeSessionPeerManager() *bsspm.SessionPeerManager {
 	return bsspm.New(1, newFakePeerTagger())
 }
 
-type fakePeerTagger struct {
-}
-
 func newFakePeerTagger() *fakePeerTagger {
-	return &fakePeerTagger{}
+	return &fakePeerTagger{
+		protectedPeers: make(map[peer.ID]map[string]struct{}),
+	}
 }
 
-func (fpt *fakePeerTagger) TagPeer(p peer.ID, tag string, val int) {
+type fakePeerTagger struct {
+	lk             sync.Mutex
+	protectedPeers map[peer.ID]map[string]struct{}
 }
-func (fpt *fakePeerTagger) UntagPeer(p peer.ID, tag string) {
+
+func (fpt *fakePeerTagger) TagPeer(p peer.ID, tag string, val int) {}
+func (fpt *fakePeerTagger) UntagPeer(p peer.ID, tag string)        {}
+
+func (fpt *fakePeerTagger) Protect(p peer.ID, tag string) {
+	fpt.lk.Lock()
+	defer fpt.lk.Unlock()
+
+	tags, ok := fpt.protectedPeers[p]
+	if !ok {
+		tags = make(map[string]struct{})
+		fpt.protectedPeers[p] = tags
+	}
+	tags[tag] = struct{}{}
+}
+
+func (fpt *fakePeerTagger) Unprotect(p peer.ID, tag string) bool {
+	fpt.lk.Lock()
+	defer fpt.lk.Unlock()
+
+	if tags, ok := fpt.protectedPeers[p]; ok {
+		delete(tags, tag)
+		return len(tags) > 0
+	}
+
+	return false
 }
 
 type fakeProviderFinder struct {

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -94,6 +94,14 @@ func (fpt *fakePeerTagger) Unprotect(p peer.ID, tag string) bool {
 	return false
 }
 
+func (fpt *fakePeerTagger) isProtected(p peer.ID, tag string) bool {
+	fpt.lk.Lock()
+	defer fpt.lk.Unlock()
+
+	_, ok := fpt.protectedPeers[p][tag]
+	return ok
+}
+
 type fakeProviderFinder struct {
 	findMorePeersRequested chan cid.Cid
 }

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -94,12 +94,11 @@ func (fpt *fakePeerTagger) Unprotect(p peer.ID, tag string) bool {
 	return false
 }
 
-func (fpt *fakePeerTagger) isProtected(p peer.ID, tag string) bool {
+func (fpt *fakePeerTagger) isProtected(p peer.ID) bool {
 	fpt.lk.Lock()
 	defer fpt.lk.Unlock()
 
-	_, ok := fpt.protectedPeers[p][tag]
-	return ok
+	return len(fpt.protectedPeers[p]) > 0
 }
 
 type fakeProviderFinder struct {

--- a/internal/session/sessionwantsender.go
+++ b/internal/session/sessionwantsender.go
@@ -379,6 +379,11 @@ func (sws *sessionWantSender) processUpdates(updates []update) []cid.Cid {
 				// Inform the peer tracker that this peer was the first to send
 				// us the block
 				sws.peerRspTrkr.receivedBlockFrom(upd.from)
+
+				// Protect the connection to this peer so that we can ensure
+				// that the connection doesn't get pruned by the connection
+				// manager
+				sws.spm.ProtectConnection(upd.from)
 			}
 			delete(sws.peerConsecutiveDontHaves, upd.from)
 		}

--- a/internal/session/sessionwantsender_test.go
+++ b/internal/session/sessionwantsender_test.go
@@ -406,7 +406,7 @@ func TestProtectConnFirstPeerToSendWantedBlock(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Expect peer A to be protected as it was first to send the block
-	if _, ok := fpt.protectedPeers[peerA][sidStr]; !ok {
+	if !fpt.isProtected(peerA, sidStr) {
 		t.Fatal("Expected first peer to send block to have protected connection")
 	}
 
@@ -417,7 +417,7 @@ func TestProtectConnFirstPeerToSendWantedBlock(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Expect peer B not to be protected as it was not first to send the block
-	if _, ok := fpt.protectedPeers[peerB][sidStr]; ok {
+	if fpt.isProtected(peerB, sidStr) {
 		t.Fatal("Expected peer not to be protected")
 	}
 
@@ -428,7 +428,7 @@ func TestProtectConnFirstPeerToSendWantedBlock(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Expect peer C not to be protected as we didn't want the block it sent
-	if _, ok := fpt.protectedPeers[peerC][sidStr]; ok {
+	if fpt.isProtected(peerC, sidStr) {
 		t.Fatal("Expected peer not to be protected")
 	}
 }

--- a/internal/session/sessionwantsender_test.go
+++ b/internal/session/sessionwantsender_test.go
@@ -2,7 +2,6 @@ package session
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -383,7 +382,6 @@ func TestProtectConnFirstPeerToSendWantedBlock(t *testing.T) {
 	peerB := peers[1]
 	peerC := peers[2]
 	sid := uint64(1)
-	sidStr := fmt.Sprintf("%d", sid)
 	pm := newMockPeerManager()
 	fpt := newFakePeerTagger()
 	fpm := bsspm.New(1, fpt)
@@ -406,7 +404,7 @@ func TestProtectConnFirstPeerToSendWantedBlock(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Expect peer A to be protected as it was first to send the block
-	if !fpt.isProtected(peerA, sidStr) {
+	if !fpt.isProtected(peerA) {
 		t.Fatal("Expected first peer to send block to have protected connection")
 	}
 
@@ -417,7 +415,7 @@ func TestProtectConnFirstPeerToSendWantedBlock(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Expect peer B not to be protected as it was not first to send the block
-	if fpt.isProtected(peerB, sidStr) {
+	if fpt.isProtected(peerB) {
 		t.Fatal("Expected peer not to be protected")
 	}
 
@@ -428,7 +426,7 @@ func TestProtectConnFirstPeerToSendWantedBlock(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Expect peer C not to be protected as we didn't want the block it sent
-	if fpt.isProtected(peerC, sidStr) {
+	if fpt.isProtected(peerC) {
 		t.Fatal("Expected peer not to be protected")
 	}
 }

--- a/internal/sessionmanager/sessionmanager_test.go
+++ b/internal/sessionmanager/sessionmanager_test.go
@@ -51,12 +51,13 @@ func (fs *fakeSession) Shutdown() {
 type fakeSesPeerManager struct {
 }
 
-func (*fakeSesPeerManager) Peers() []peer.ID        { return nil }
-func (*fakeSesPeerManager) PeersDiscovered() bool   { return false }
-func (*fakeSesPeerManager) Shutdown()               {}
-func (*fakeSesPeerManager) AddPeer(peer.ID) bool    { return false }
-func (*fakeSesPeerManager) RemovePeer(peer.ID) bool { return false }
-func (*fakeSesPeerManager) HasPeers() bool          { return false }
+func (*fakeSesPeerManager) Peers() []peer.ID          { return nil }
+func (*fakeSesPeerManager) PeersDiscovered() bool     { return false }
+func (*fakeSesPeerManager) Shutdown()                 {}
+func (*fakeSesPeerManager) AddPeer(peer.ID) bool      { return false }
+func (*fakeSesPeerManager) RemovePeer(peer.ID) bool   { return false }
+func (*fakeSesPeerManager) HasPeers() bool            { return false }
+func (*fakeSesPeerManager) ProtectConnection(peer.ID) {}
 
 type fakePeerManager struct {
 	lk      sync.Mutex

--- a/internal/sessionpeermanager/sessionpeermanager.go
+++ b/internal/sessionpeermanager/sessionpeermanager.go
@@ -78,7 +78,7 @@ func (spm *SessionPeerManager) ProtectConnection(p peer.ID) {
 		return
 	}
 
-	spm.tagger.Protect(p, fmt.Sprintf("%d", spm.id))
+	spm.tagger.Protect(p, spm.protectedTag())
 }
 
 // RemovePeer removes the peer from the SessionPeerManager.
@@ -93,7 +93,7 @@ func (spm *SessionPeerManager) RemovePeer(p peer.ID) bool {
 
 	delete(spm.peers, p)
 	spm.tagger.UntagPeer(p, spm.tag)
-	spm.tagger.Unprotect(p, fmt.Sprintf("%d", spm.id))
+	spm.tagger.Unprotect(p, spm.protectedTag())
 
 	log.Debugw("Bitswap: removed peer from session", "session", spm.id, "peer", p, "peerCount", len(spm.peers))
 	return true
@@ -145,5 +145,10 @@ func (spm *SessionPeerManager) Shutdown() {
 	// connections to those peers
 	for p := range spm.peers {
 		spm.tagger.UntagPeer(p, spm.tag)
+		spm.tagger.Unprotect(p, spm.protectedTag())
 	}
+}
+
+func (spm *SessionPeerManager) protectedTag() string {
+	return fmt.Sprintf("%d", spm.id)
 }

--- a/internal/sessionpeermanager/sessionpeermanager.go
+++ b/internal/sessionpeermanager/sessionpeermanager.go
@@ -78,7 +78,7 @@ func (spm *SessionPeerManager) ProtectConnection(p peer.ID) {
 		return
 	}
 
-	spm.tagger.Protect(p, spm.protectedTag())
+	spm.tagger.Protect(p, spm.tag)
 }
 
 // RemovePeer removes the peer from the SessionPeerManager.
@@ -93,7 +93,7 @@ func (spm *SessionPeerManager) RemovePeer(p peer.ID) bool {
 
 	delete(spm.peers, p)
 	spm.tagger.UntagPeer(p, spm.tag)
-	spm.tagger.Unprotect(p, spm.protectedTag())
+	spm.tagger.Unprotect(p, spm.tag)
 
 	log.Debugw("Bitswap: removed peer from session", "session", spm.id, "peer", p, "peerCount", len(spm.peers))
 	return true
@@ -145,10 +145,6 @@ func (spm *SessionPeerManager) Shutdown() {
 	// connections to those peers
 	for p := range spm.peers {
 		spm.tagger.UntagPeer(p, spm.tag)
-		spm.tagger.Unprotect(p, spm.protectedTag())
+		spm.tagger.Unprotect(p, spm.tag)
 	}
-}
-
-func (spm *SessionPeerManager) protectedTag() string {
-	return fmt.Sprintf("%d", spm.id)
 }

--- a/internal/sessionpeermanager/sessionpeermanager.go
+++ b/internal/sessionpeermanager/sessionpeermanager.go
@@ -21,6 +21,8 @@ const (
 type PeerTagger interface {
 	TagPeer(peer.ID, string, int)
 	UntagPeer(p peer.ID, tag string)
+	Protect(peer.ID, string)
+	Unprotect(peer.ID, string) bool
 }
 
 // SessionPeerManager keeps track of peers for a session, and takes care of
@@ -67,6 +69,18 @@ func (spm *SessionPeerManager) AddPeer(p peer.ID) bool {
 	return true
 }
 
+// Protect connection to this peer from being pruned by the connection manager
+func (spm *SessionPeerManager) ProtectConnection(p peer.ID) {
+	spm.plk.Lock()
+	defer spm.plk.Unlock()
+
+	if _, ok := spm.peers[p]; !ok {
+		return
+	}
+
+	spm.tagger.Protect(p, fmt.Sprintf("%d", spm.id))
+}
+
 // RemovePeer removes the peer from the SessionPeerManager.
 // Returns true if the peer was removed, false if it did not exist.
 func (spm *SessionPeerManager) RemovePeer(p peer.ID) bool {
@@ -79,6 +93,7 @@ func (spm *SessionPeerManager) RemovePeer(p peer.ID) bool {
 
 	delete(spm.peers, p)
 	spm.tagger.UntagPeer(p, spm.tag)
+	spm.tagger.Unprotect(p, fmt.Sprintf("%d", spm.id))
 
 	log.Debugw("Bitswap: removed peer from session", "session", spm.id, "peer", p, "peerCount", len(spm.peers))
 	return true


### PR DESCRIPTION
When receiving blocks, if the peer that sent the block was the first to send it, protect the connection to the peer, so that it doesn't get pruned by the connection manager.