### PR TITLE
refactor: simplify and harden receive metrics

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -267,7 +267,6 @@ type counters struct {
 	blocksSent     uint64
 	dataSent       uint64
 	dataRecvd      uint64
-	messagesRecvd  uint64
 }
 
 // GetBlock attempts to retrieve a particular block from peers within the
@@ -353,10 +352,6 @@ func (bs *Bitswap) processNewBlocks(blks []blocks.Block) error {
 // ReceiveMessage is called by the network interface when a new message is
 // received.
 func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg.BitSwapMessage) {
-	bs.counterLk.Lock()
-	bs.counters.messagesRecvd++
-	bs.counterLk.Unlock()
-
 	select {
 	case <-bs.process.Closing():
 		return

--- a/stat.go
+++ b/stat.go
@@ -18,10 +18,13 @@ type Stat struct {
 	DupBlksReceived  uint64
 	DupDataReceived  uint64
 	MessagesReceived uint64
+	MessagesSent     uint64
 }
 
 // Stat returns aggregated statistics about bitswap operations
 func (bs *Bitswap) Stat() (*Stat, error) {
+	nstats := bs.network.Stats()
+
 	st := new(Stat)
 	st.ProvideBufLen = len(bs.newBlocks)
 	st.Wantlist = bs.GetWantlist()
@@ -33,7 +36,8 @@ func (bs *Bitswap) Stat() (*Stat, error) {
 	st.BlocksSent = c.blocksSent
 	st.DataSent = c.dataSent
 	st.DataReceived = c.dataRecvd
-	st.MessagesReceived = c.messagesRecvd
+	st.MessagesReceived = nstats.MessagesRecvd
+	st.MessagesSent = nstats.MessagesSent
 	bs.counterLk.Unlock()
 
 	peers := bs.engine.Peers()


### PR DESCRIPTION
* Count wanted blocks without checking the blockstore.
* Shrink critical sections.