### PR TITLE
wire a context in most of Datastore/Blockstore methods, connect a few

### DIFF
--- a/bitswap_with_sessions_test.go
+++ b/bitswap_with_sessions_test.go
@@ -34,7 +34,7 @@ func TestBasicSessions(t *testing.T) {
 	b := inst[1]
 
 	// Add a block to Peer B
-	if err := b.Blockstore().Put(block); err != nil {
+	if err := b.Blockstore().Put(ctx, block); err != nil {
 		t.Fatal(err)
 	}
 
@@ -82,7 +82,7 @@ func TestSessionBetweenPeers(t *testing.T) {
 
 	// Add 101 blocks to Peer A
 	blks := bgen.Blocks(101)
-	if err := inst[0].Blockstore().PutMany(blks); err != nil {
+	if err := inst[0].Blockstore().PutMany(ctx, blks); err != nil {
 		t.Fatal(err)
 	}
 
@@ -143,7 +143,7 @@ func TestSessionSplitFetch(t *testing.T) {
 	// Add 10 distinct blocks to each of 10 peers
 	blks := bgen.Blocks(100)
 	for i := 0; i < 10; i++ {
-		if err := inst[i].Blockstore().PutMany(blks[i*10 : (i+1)*10]); err != nil {
+		if err := inst[i].Blockstore().PutMany(ctx, blks[i*10:(i+1)*10]); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -187,7 +187,7 @@ func TestFetchNotConnected(t *testing.T) {
 	// Provide 10 blocks on Peer A
 	blks := bgen.Blocks(10)
 	for _, block := range blks {
-		if err := other.Exchange.HasBlock(block); err != nil {
+		if err := other.Exchange.HasBlock(ctx, block); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -243,7 +243,7 @@ func TestFetchAfterDisconnect(t *testing.T) {
 
 	firstBlks := blks[:5]
 	for _, block := range firstBlks {
-		if err := peerA.Exchange.HasBlock(block); err != nil {
+		if err := peerA.Exchange.HasBlock(ctx, block); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -279,7 +279,7 @@ func TestFetchAfterDisconnect(t *testing.T) {
 	// Provide remaining blocks
 	lastBlks := blks[5:]
 	for _, block := range lastBlks {
-		if err := peerA.Exchange.HasBlock(block); err != nil {
+		if err := peerA.Exchange.HasBlock(ctx, block); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -334,7 +334,7 @@ func TestInterestCacheOverflow(t *testing.T) {
 	// wait to ensure that all the above cids were added to the sessions cache
 	time.Sleep(time.Millisecond * 50)
 
-	if err := b.Exchange.HasBlock(blks[0]); err != nil {
+	if err := b.Exchange.HasBlock(ctx, blks[0]); err != nil {
 		t.Fatal(err)
 	}
 
@@ -381,7 +381,7 @@ func TestPutAfterSessionCacheEvict(t *testing.T) {
 	// wait to ensure that all the above cids were added to the sessions cache
 	time.Sleep(time.Millisecond * 50)
 
-	if err := a.Exchange.HasBlock(blks[17]); err != nil {
+	if err := a.Exchange.HasBlock(ctx, blks[17]); err != nil {
 		t.Fatal(err)
 	}
 
@@ -423,7 +423,7 @@ func TestMultipleSessions(t *testing.T) {
 	}
 
 	time.Sleep(time.Millisecond * 10)
-	if err := b.Exchange.HasBlock(blk); err != nil {
+	if err := b.Exchange.HasBlock(ctx, blk); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/decision/blockstoremanager.go
+++ b/internal/decision/blockstoremanager.go
@@ -70,7 +70,7 @@ func (bsm *blockstoreManager) getBlockSizes(ctx context.Context, ks []cid.Cid) (
 
 	var lk sync.Mutex
 	return res, bsm.jobPerKey(ctx, ks, func(c cid.Cid) {
-		size, err := bsm.bs.GetSize(c)
+		size, err := bsm.bs.GetSize(ctx, c)
 		if err != nil {
 			if err != bstore.ErrNotFound {
 				// Note: this isn't a fatal error. We shouldn't abort the request
@@ -92,7 +92,7 @@ func (bsm *blockstoreManager) getBlocks(ctx context.Context, ks []cid.Cid) (map[
 
 	var lk sync.Mutex
 	return res, bsm.jobPerKey(ctx, ks, func(c cid.Cid) {
-		blk, err := bsm.bs.Get(c)
+		blk, err := bsm.bs.Get(ctx, c)
 		if err != nil {
 			if err != bstore.ErrNotFound {
 				// Note: this isn't a fatal error. We shouldn't abort the request

--- a/internal/decision/blockstoremanager_test.go
+++ b/internal/decision/blockstoremanager_test.go
@@ -78,7 +78,7 @@ func TestBlockstoreManager(t *testing.T) {
 	}
 
 	// Put all blocks in the blockstore except the last one
-	if err := bstore.PutMany(blks[:len(blks)-1]); err != nil {
+	if err := bstore.PutMany(ctx, blks[:len(blks)-1]); err != nil {
 		t.Fatal(err)
 	}
 
@@ -158,7 +158,7 @@ func TestBlockstoreManagerConcurrency(t *testing.T) {
 		ks = append(ks, b.Cid())
 	}
 
-	err := bstore.PutMany(blks)
+	err := bstore.PutMany(ctx, blks)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestBlockstoreManagerClose(t *testing.T) {
 		ks = append(ks, b.Cid())
 	}
 
-	err := bstore.PutMany(blks)
+	err := bstore.PutMany(ctx, blks)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,6 +221,7 @@ func TestBlockstoreManagerClose(t *testing.T) {
 }
 
 func TestBlockstoreManagerCtxDone(t *testing.T) {
+	ctx := context.Background()
 	delayTime := 20 * time.Millisecond
 	bsdelay := delay.Fixed(delayTime)
 
@@ -237,7 +238,7 @@ func TestBlockstoreManagerCtxDone(t *testing.T) {
 		ks = append(ks, b.Cid())
 	}
 
-	err := bstore.PutMany(blks)
+	err := bstore.PutMany(ctx, blks)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/decision/engine_test.go
+++ b/internal/decision/engine_test.go
@@ -203,13 +203,14 @@ func TestOutboxClosedWhenEngineClosed(t *testing.T) {
 }
 
 func TestPartnerWantHaveWantBlockNonActive(t *testing.T) {
+	ctx := context.Background()
 	alphabet := "abcdefghijklmnopqrstuvwxyz"
 	vowels := "aeiou"
 
 	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
 	for _, letter := range strings.Split(alphabet, "") {
 		block := blocks.NewBlock([]byte(letter))
-		if err := bs.Put(block); err != nil {
+		if err := bs.Put(ctx, block); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -542,12 +543,13 @@ func TestPartnerWantHaveWantBlockNonActive(t *testing.T) {
 }
 
 func TestPartnerWantHaveWantBlockActive(t *testing.T) {
+	ctx := context.Background()
 	alphabet := "abcdefghijklmnopqrstuvwxyz"
 
 	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
 	for _, letter := range strings.Split(alphabet, "") {
 		block := blocks.NewBlock([]byte(letter))
-		if err := bs.Put(block); err != nil {
+		if err := bs.Put(ctx, block); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -813,6 +815,7 @@ func formatPresencesDiff(presences []message.BlockPresence, expHaves []string, e
 }
 
 func TestPartnerWantsThenCancels(t *testing.T) {
+	ctx := context.Background()
 	numRounds := 10
 	if testing.Short() {
 		numRounds = 1
@@ -846,12 +849,11 @@ func TestPartnerWantsThenCancels(t *testing.T) {
 	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
 	for _, letter := range alphabet {
 		block := blocks.NewBlock([]byte(letter))
-		if err := bs.Put(block); err != nil {
+		if err := bs.Put(ctx, block); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	ctx := context.Background()
 	for i := 0; i < numRounds; i++ {
 		expected := make([][]string, 0, len(testcases))
 		e := newEngine(ctx, bs, &fakePeerTagger{}, "localhost", 0, shortTerm, nil)
@@ -875,6 +877,7 @@ func TestPartnerWantsThenCancels(t *testing.T) {
 }
 
 func TestSendReceivedBlocksToPeersThatWantThem(t *testing.T) {
+	ctx := context.Background()
 	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
 	partner := libp2ptest.RandPeerIDFatal(t)
 	otherPeer := libp2ptest.RandPeerIDFatal(t)
@@ -897,7 +900,7 @@ func TestSendReceivedBlocksToPeersThatWantThem(t *testing.T) {
 		t.Fatal("expected no envelope yet")
 	}
 
-	if err := bs.PutMany([]blocks.Block{blks[0], blks[2]}); err != nil {
+	if err := bs.PutMany(ctx, []blocks.Block{blks[0], blks[2]}); err != nil {
 		t.Fatal(err)
 	}
 	e.ReceiveFrom(otherPeer, []blocks.Block{blks[0], blks[2]}, []cid.Cid{})
@@ -919,6 +922,7 @@ func TestSendReceivedBlocksToPeersThatWantThem(t *testing.T) {
 }
 
 func TestSendDontHave(t *testing.T) {
+	ctx := context.Background()
 	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
 	partner := libp2ptest.RandPeerIDFatal(t)
 	otherPeer := libp2ptest.RandPeerIDFatal(t)
@@ -960,7 +964,7 @@ func TestSendDontHave(t *testing.T) {
 	}
 
 	// Receive all the blocks
-	if err := bs.PutMany(blks); err != nil {
+	if err := bs.PutMany(ctx, blks); err != nil {
 		t.Fatal(err)
 	}
 	e.ReceiveFrom(otherPeer, blks, []cid.Cid{})
@@ -1025,7 +1029,7 @@ func TestTaggingPeers(t *testing.T) {
 	keys := []string{"a", "b", "c", "d", "e"}
 	for _, letter := range keys {
 		block := blocks.NewBlock([]byte(letter))
-		if err := sanfrancisco.Blockstore.Put(block); err != nil {
+		if err := sanfrancisco.Blockstore.Put(ctx, block); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Master issue: https://github.com/ipfs/go-ipfs/issues/6803

This only do the wiring. Actual usage for cancellation, logging or tracing is
left for a future work.