### PR TITLE
fix: don't say we're sending a full wantlist unless we are

### DIFF
--- a/internal/decision/engine.go
+++ b/internal/decision/engine.go
@@ -421,7 +421,7 @@ func (e *Engine) nextEnvelope(ctx context.Context) (*Envelope, error) {
 		}
 
 		// Create a new message
-		msg := bsmsg.New(true)
+		msg := bsmsg.New(false)
 
 		log.Debugw("Bitswap process tasks", "local", e.self, "taskCount", len(nextTasks))
 


### PR DESCRIPTION
I'm not sure why we set "full" to true here, but this could be the source of a whole bunch of bidirectional sync issues. That is, if two peers are syncing off each other, they could repeatedly "reset" each other's wantlist to "empty".