### PR TITLE
fix: set the score ledger on start

### DIFF
--- a/internal/decision/engine.go
+++ b/internal/decision/engine.go
@@ -178,6 +178,10 @@ func NewEngine(ctx context.Context, bs bstore.Blockstore, peerTagger PeerTagger,
 func newEngine(ctx context.Context, bs bstore.Blockstore, peerTagger PeerTagger, self peer.ID,
 	maxReplaceSize int, scoreLedger ScoreLedger) *Engine {
 
+	if scoreLedger == nil {
+		scoreLedger = NewDefaultScoreLedger()
+	}
+
 	e := &Engine{
 		ledgerMap:                       make(map[peer.ID]*ledger),
 		scoreLedger:                     scoreLedger,
@@ -221,9 +225,6 @@ func (e *Engine) UseScoreLedger(scoreLedger ScoreLedger) {
 // if it is unset, initializes the scoreLedger with the default
 // implementation.
 func (e *Engine) startScoreLedger(px process.Process) {
-	if e.scoreLedger == nil {
-		e.scoreLedger = NewDefaultScoreLedger()
-	}
 	e.scoreLedger.Start(func(p peer.ID, score int) {
 		if score == 0 {
 			e.peerTagger.UntagPeer(p, e.tagUseful)

--- a/internal/decision/scoreledger.go
+++ b/internal/decision/scoreledger.go
@@ -102,8 +102,6 @@ func (l *scoreledger) Receipt() *Receipt {
 
 // DefaultScoreLedger is used by Engine as the default ScoreLedger.
 type DefaultScoreLedger struct {
-	// a sample counting ticker
-	ticker *time.Ticker
 	// the score func
 	scorePeer ScorePeerFunc
 	// is closed on Close
@@ -333,7 +331,6 @@ func (dsl *DefaultScoreLedger) PeerDisconnected(p peer.ID) {
 func NewDefaultScoreLedger() *DefaultScoreLedger {
 	return &DefaultScoreLedger{
 		ledgerMap:          make(map[peer.ID]*scoreledger),
-		ticker:             time.NewTicker(time.Millisecond * 100),
 		closing:            make(chan struct{}),
 		peerSampleInterval: shortTerm,
 	}


### PR DESCRIPTION
It's possible to start receiving and processing messages before we get around to starting.