### PR TITLE
fix(network): impl: add timeout in newStreamToPeer call

### DIFF
--- a/network/ipfs_impl.go
+++ b/network/ipfs_impl.go
@@ -27,6 +27,7 @@ import (
 
 var log = logging.Logger("bitswap_network")
 
+var connectTimeout = time.Second * 5
 var sendMessageTimeout = time.Minute * 10
 
 // NewFromIpfsHost returns a BitSwapNetwork supported by underlying IPFS host.
@@ -312,7 +313,10 @@ func (bsnet *impl) SendMessage(
 	p peer.ID,
 	outgoing bsmsg.BitSwapMessage) error {
 
-	s, err := bsnet.newStreamToPeer(ctx, p)
+	tctx, cancel := context.WithTimeout(ctx, connectTimeout)
+	defer cancel()
+
+	s, err := bsnet.newStreamToPeer(tctx, p)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
See https://github.com/ipfs/go-ipfs/issues/7972#issuecomment-824327775 for background.

If there is a straightforward 10-line way to test this I can add it, otherwise I'll just leave the fix.