### PR TITLE
fix: fix alignment of stats struct in virtual network

### DIFF
--- a/testnet/virtual.go
+++ b/testnet/virtual.go
@@ -184,11 +184,13 @@ func (n *network) SendMessage(
 }
 
 type networkClient struct {
+	// These need to be at the top of the struct (allocated on the heap) for alignment on 32bit platforms.
+	stats bsnet.Stats
+
 	local peer.ID
 	bsnet.Receiver
 	network            *network
 	routing            routing.Routing
-	stats              bsnet.Stats
 	supportedProtocols []protocol.ID
 }
 


### PR DESCRIPTION
This needs to be at the top of the "allocated" struct. Otherwise, 32bit tests fail.