### PR TITLE
fix: Nil dereference while using SetSendDontHaves

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -308,7 +308,7 @@ type Bitswap struct {
 
 	// indicates what to do when the engine receives a want-block for a block that
 	// is not in the blockstore. Either send DONT_HAVE or do nothing.
-	// This is used to simulate with old version of bitswap that were quiets.
+	// This is used to simulate older versions of bitswap that did nothing instead of sending back a DONT_HAVE.
 	engineSetSendDontHaves bool
 
 	// whether we should actually simulate dont haves on request timeout

--- a/bitswap.go
+++ b/bitswap.go
@@ -107,7 +107,7 @@ func EngineBlockstoreWorkerCount(count int) Option {
 // This option is only used for testing.
 func SetSendDontHaves(send bool) Option {
 	return func(bs *Bitswap) {
-		bs.engine.SetSendDontHaves(send)
+		bs.engineSetSendDontHaves = send
 	}
 }
 
@@ -210,6 +210,7 @@ func New(parent context.Context, network bsnet.BitSwapNetwork,
 		provSearchDelay:            defaultProvSearchDelay,
 		rebroadcastDelay:           delay.Fixed(time.Minute),
 		engineBstoreWorkerCount:    defaulEngineBlockstoreWorkerCount,
+		engineSetSendDontHaves:     true,
 		simulateDontHavesOnTimeout: true,
 	}
 
@@ -220,6 +221,7 @@ func New(parent context.Context, network bsnet.BitSwapNetwork,
 
 	// Set up decision engine
 	bs.engine = decision.NewEngine(bstore, bs.engineBstoreWorkerCount, network.ConnectionManager(), network.Self(), bs.engineScoreLedger)
+	bs.engine.SetSendDontHaves(bs.engineSetSendDontHaves)
 
 	bs.pqm.Startup()
 	network.SetDelegate(bs)
@@ -303,6 +305,11 @@ type Bitswap struct {
 
 	// the score ledger used by the decision engine
 	engineScoreLedger deciface.ScoreLedger
+
+	// indicates what to do when the engine receives a want-block for a block that
+	// is not in the blockstore. Either send DONT_HAVE or do nothing.
+	// This is used to simulate with old version of bitswap that were quiets.
+	engineSetSendDontHaves bool
 
 	// whether we should actually simulate dont haves on request timeout
 	simulateDontHavesOnTimeout bool


### PR DESCRIPTION
This option is used by the benchmark to simulate the old bitswap comportement (and fixes the benchmark).

This follows the same refactoring idea as done in 47b99b1ce34a.

It was crashing since it was trying to access the `sendDontHaves` property of `bs.engine` but `bs.engine` is initialized right after the options are applied, not before.

Unlike 47b99b1ce34a, I've choosed to not make `sendDontHaves` part of engine's constructor because this is such an obscure option, useless in +99% of realworld scenario that it's not needed to confuse the engine contructor.