### PR TITLE
Fix/fix test tagging useful

### DIFF
--- a/internal/decision/engine_test.go
+++ b/internal/decision/engine_test.go
@@ -1044,7 +1044,7 @@ func TestTaggingPeers(t *testing.T) {
 }
 
 func TestTaggingUseful(t *testing.T) {
-	peerSampleInterval := 1 * time.Millisecond
+	peerSampleInterval := 20 * time.Millisecond
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
# Goals

fix #472

# Implementation

The TestTaggingUseful test was flaky due to a very low test interval (1 millisecond) -- causing
unpredictable behavior. I find it is pretty dangerous to rely on timers across OS that are <10
milliseconds. This does mean the test takes slightly longer, but should be much more reliable