### PR TITLE
Fix flaky DontHaveTimeoutManger tests

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -118,9 +118,9 @@ func WithScoreLedger(scoreLedger deciface.ScoreLedger) Option {
 	}
 }
 
-func SetSendDontHavesOnTimeout(send bool) Option {
+func SetSimulateDontHavesOnTimeout(send bool) Option {
 	return func(bs *Bitswap) {
-		bs.sendDontHavesOnTimeout = send
+		bs.simulateDontHavesOnTimeout = send
 	}
 }
 
@@ -158,7 +158,7 @@ func New(parent context.Context, network bsnet.BitSwapNetwork,
 	var bs *Bitswap
 	onDontHaveTimeout := func(p peer.ID, dontHaves []cid.Cid) {
 		// Simulate a message arriving with DONT_HAVEs
-		if bs.sendDontHavesOnTimeout {
+		if bs.simulateDontHavesOnTimeout {
 			sm.ReceiveFrom(ctx, p, nil, nil, dontHaves)
 		}
 	}
@@ -192,25 +192,25 @@ func New(parent context.Context, network bsnet.BitSwapNetwork,
 	sm = bssm.New(ctx, sessionFactory, sim, sessionPeerManagerFactory, bpm, pm, notif, network.Self())
 
 	bs = &Bitswap{
-		blockstore:              bstore,
-		network:                 network,
-		process:                 px,
-		newBlocks:               make(chan cid.Cid, HasBlockBufferSize),
-		provideKeys:             make(chan cid.Cid, provideKeysBufferSize),
-		pm:                      pm,
-		pqm:                     pqm,
-		sm:                      sm,
-		sim:                     sim,
-		notif:                   notif,
-		counters:                new(counters),
-		dupMetric:               dupHist,
-		allMetric:               allHist,
-		sentHistogram:           sentHistogram,
-		provideEnabled:          true,
-		provSearchDelay:         defaultProvSearchDelay,
-		rebroadcastDelay:        delay.Fixed(time.Minute),
-		engineBstoreWorkerCount: defaulEngineBlockstoreWorkerCount,
-		sendDontHavesOnTimeout:  true,
+		blockstore:                 bstore,
+		network:                    network,
+		process:                    px,
+		newBlocks:                  make(chan cid.Cid, HasBlockBufferSize),
+		provideKeys:                make(chan cid.Cid, provideKeysBufferSize),
+		pm:                         pm,
+		pqm:                        pqm,
+		sm:                         sm,
+		sim:                        sim,
+		notif:                      notif,
+		counters:                   new(counters),
+		dupMetric:                  dupHist,
+		allMetric:                  allHist,
+		sentHistogram:              sentHistogram,
+		provideEnabled:             true,
+		provSearchDelay:            defaultProvSearchDelay,
+		rebroadcastDelay:           delay.Fixed(time.Minute),
+		engineBstoreWorkerCount:    defaulEngineBlockstoreWorkerCount,
+		simulateDontHavesOnTimeout: true,
 	}
 
 	// apply functional options before starting and running bitswap
@@ -305,7 +305,7 @@ type Bitswap struct {
 	engineScoreLedger deciface.ScoreLedger
 
 	// whether we should actually simulate dont haves on request timeout
-	sendDontHavesOnTimeout bool
+	simulateDontHavesOnTimeout bool
 }
 
 type counters struct {

--- a/bitswap_with_sessions_test.go
+++ b/bitswap_with_sessions_test.go
@@ -74,7 +74,7 @@ func TestSessionBetweenPeers(t *testing.T) {
 	defer cancel()
 
 	vnet := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(time.Millisecond))
-	ig := testinstance.NewTestInstanceGenerator(vnet, nil, []bitswap.Option{bitswap.SetSendDontHavesOnTimeout(false)})
+	ig := testinstance.NewTestInstanceGenerator(vnet, nil, []bitswap.Option{bitswap.SetSimulateDontHavesOnTimeout(false)})
 	defer ig.Close()
 	bgen := blocksutil.NewBlockGenerator()
 

--- a/bitswap_with_sessions_test.go
+++ b/bitswap_with_sessions_test.go
@@ -74,7 +74,7 @@ func TestSessionBetweenPeers(t *testing.T) {
 	defer cancel()
 
 	vnet := tn.VirtualNetwork(mockrouting.NewServer(), delay.Fixed(time.Millisecond))
-	ig := testinstance.NewTestInstanceGenerator(vnet, nil, nil)
+	ig := testinstance.NewTestInstanceGenerator(vnet, nil, []bitswap.Option{bitswap.SetSendDontHavesOnTimeout(false)})
 	defer ig.Close()
 	bgen := blocksutil.NewBlockGenerator()
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/ipfs/go-bitswap
 
 require (
+	github.com/benbjohnson/clock v1.1.0
 	github.com/cskr/pubsub v1.0.2
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETF
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=
 github.com/btcsuite/btcd v0.0.0-20190523000118-16327141da8c/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
 github.com/btcsuite/btcd v0.0.0-20190824003749-130ea5bddde3/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=

--- a/internal/decision/scoreledger.go
+++ b/internal/decision/scoreledger.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -55,6 +56,8 @@ type scoreledger struct {
 
 	// the record lock
 	lock sync.RWMutex
+
+	clock clock.Clock
 }
 
 // Receipt is a summary of the ledger for a given peer
@@ -73,7 +76,7 @@ func (l *scoreledger) AddToSentBytes(n int) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 	l.exchangeCount++
-	l.lastExchange = time.Now()
+	l.lastExchange = l.clock.Now()
 	l.bytesSent += uint64(n)
 }
 
@@ -82,7 +85,7 @@ func (l *scoreledger) AddToReceivedBytes(n int) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 	l.exchangeCount++
-	l.lastExchange = time.Now()
+	l.lastExchange = l.clock.Now()
 	l.bytesRecv += uint64(n)
 }
 
@@ -114,6 +117,7 @@ type DefaultScoreLedger struct {
 	peerSampleInterval time.Duration
 	// used by the tests to detect when a sample is taken
 	sampleCh chan struct{}
+	clock    clock.Clock
 }
 
 // scoreWorker keeps track of how "useful" our peers are, updating scores in the
@@ -134,7 +138,7 @@ type DefaultScoreLedger struct {
 // adjust it ±25% based on our debt ratio. Peers that have historically been
 // more useful to us than we are to them get the highest score.
 func (dsl *DefaultScoreLedger) scoreWorker() {
-	ticker := time.NewTicker(dsl.peerSampleInterval)
+	ticker := dsl.clock.Ticker(dsl.peerSampleInterval)
 	defer ticker.Stop()
 
 	type update struct {
@@ -236,9 +240,10 @@ func (dsl *DefaultScoreLedger) find(p peer.ID) *scoreledger {
 }
 
 // Returns a new scoreledger.
-func newScoreLedger(p peer.ID) *scoreledger {
+func newScoreLedger(p peer.ID, clock clock.Clock) *scoreledger {
 	return &scoreledger{
 		partner: p,
+		clock:   clock,
 	}
 }
 
@@ -255,7 +260,7 @@ func (dsl *DefaultScoreLedger) findOrCreate(p peer.ID) *scoreledger {
 	defer dsl.lock.Unlock()
 	l, ok := dsl.ledgerMap[p]
 	if !ok {
-		l = newScoreLedger(p)
+		l = newScoreLedger(p, dsl.clock)
 		dsl.ledgerMap[p] = l
 	}
 	return l
@@ -315,7 +320,7 @@ func (dsl *DefaultScoreLedger) PeerConnected(p peer.ID) {
 	defer dsl.lock.Unlock()
 	_, ok := dsl.ledgerMap[p]
 	if !ok {
-		dsl.ledgerMap[p] = newScoreLedger(p)
+		dsl.ledgerMap[p] = newScoreLedger(p, dsl.clock)
 	}
 }
 
@@ -333,14 +338,16 @@ func NewDefaultScoreLedger() *DefaultScoreLedger {
 		ledgerMap:          make(map[peer.ID]*scoreledger),
 		closing:            make(chan struct{}),
 		peerSampleInterval: shortTerm,
+		clock:              clock.New(),
 	}
 }
 
 // Creates a new instance of the default score ledger with testing
 // parameters.
-func NewTestScoreLedger(peerSampleInterval time.Duration, sampleCh chan struct{}) *DefaultScoreLedger {
+func NewTestScoreLedger(peerSampleInterval time.Duration, sampleCh chan struct{}, clock clock.Clock) *DefaultScoreLedger {
 	dsl := NewDefaultScoreLedger()
 	dsl.peerSampleInterval = peerSampleInterval
 	dsl.sampleCh = sampleCh
+	dsl.clock = clock
 	return dsl
 }

--- a/internal/messagequeue/donthavetimeoutmgr.go
+++ b/internal/messagequeue/donthavetimeoutmgr.go
@@ -86,8 +86,8 @@ type dontHaveTimeoutMgr struct {
 	messageLatency *latencyEwma
 	// timer used to wait until want at front of queue expires
 	checkForTimeoutsTimer *clock.Timer
-	// used for testing -- signal when a scheduled timeout check has happened
-	signal chan struct{}
+	// used for testing -- timeoutsTriggered when a scheduled dont have timeouts were triggered
+	timeoutsTriggered chan struct{}
 }
 
 // newDontHaveTimeoutMgr creates a new dontHaveTimeoutMgr
@@ -107,7 +107,7 @@ func newDontHaveTimeoutMgrWithParams(
 	messageLatencyMultiplier int,
 	maxExpectedWantProcessTime time.Duration,
 	clock clock.Clock,
-	signal chan struct{}) *dontHaveTimeoutMgr {
+	timeoutsTriggered chan struct{}) *dontHaveTimeoutMgr {
 
 	ctx, shutdown := context.WithCancel(context.Background())
 	mqp := &dontHaveTimeoutMgr{
@@ -124,7 +124,7 @@ func newDontHaveTimeoutMgrWithParams(
 		messageLatencyMultiplier:   messageLatencyMultiplier,
 		maxExpectedWantProcessTime: maxExpectedWantProcessTime,
 		onDontHaveTimeout:          onDontHaveTimeout,
-		signal:                     signal,
+		timeoutsTriggered:          timeoutsTriggered,
 	}
 
 	return mqp
@@ -351,8 +351,8 @@ func (dhtm *dontHaveTimeoutMgr) fireTimeout(pending []cid.Cid) {
 	dhtm.onDontHaveTimeout(pending)
 
 	// signal a timeout fired
-	if dhtm.signal != nil {
-		dhtm.signal <- struct{}{}
+	if dhtm.timeoutsTriggered != nil {
+		dhtm.timeoutsTriggered <- struct{}{}
 	}
 }
 

--- a/internal/messagequeue/donthavetimeoutmgr_test.go
+++ b/internal/messagequeue/donthavetimeoutmgr_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/ipfs/go-bitswap/internal/testutil"
 	cid "github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
@@ -16,10 +17,13 @@ type mockPeerConn struct {
 	err       error
 	latency   time.Duration
 	latencies []time.Duration
+	clock     clock.Clock
+	pinged    chan struct{}
 }
 
 func (pc *mockPeerConn) Ping(ctx context.Context) ping.Result {
-	timer := time.NewTimer(pc.latency)
+	timer := pc.clock.Timer(pc.latency)
+	pc.pinged <- struct{}{}
 	select {
 	case <-timer.C:
 		if pc.err != nil {
@@ -75,19 +79,21 @@ func TestDontHaveTimeoutMgrTimeout(t *testing.T) {
 	latMultiplier := 2
 	expProcessTime := 5 * time.Millisecond
 	expectedTimeout := expProcessTime + latency*time.Duration(latMultiplier)
-	pc := &mockPeerConn{latency: latency}
+	clock := clock.NewMock()
+	pinged := make(chan struct{})
+	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged}
 	tr := timeoutRecorder{}
-
+	signal := make(chan struct{})
 	dhtm := newDontHaveTimeoutMgrWithParams(pc, tr.onTimeout,
-		dontHaveTimeout, maxTimeout, latMultiplier, messageLatencyMultiplier, expProcessTime)
+		dontHaveTimeout, maxTimeout, latMultiplier, messageLatencyMultiplier, expProcessTime, clock, signal)
 	dhtm.Start()
 	defer dhtm.Shutdown()
-
+	<-pinged
 	// Add first set of keys
 	dhtm.AddPending(firstks)
 
 	// Wait for less than the expected timeout
-	time.Sleep(expectedTimeout - 10*time.Millisecond)
+	clock.Add(expectedTimeout - 10*time.Millisecond)
 
 	// At this stage no keys should have timed out
 	if tr.timedOutCount() > 0 {
@@ -98,18 +104,21 @@ func TestDontHaveTimeoutMgrTimeout(t *testing.T) {
 	dhtm.AddPending(secondks)
 
 	// Wait until after the expected timeout
-	time.Sleep(20 * time.Millisecond)
+	clock.Add(20 * time.Millisecond)
+
+	<-signal
 
 	// At this stage first set of keys should have timed out
 	if tr.timedOutCount() != len(firstks) {
 		t.Fatal("expected timeout", tr.timedOutCount(), len(firstks))
 	}
-
 	// Clear the recorded timed out keys
 	tr.clear()
 
 	// Sleep until the second set of keys should have timed out
-	time.Sleep(expectedTimeout + 10*time.Millisecond)
+	clock.Add(expectedTimeout + 10*time.Millisecond)
+
+	<-signal
 
 	// At this stage all keys should have timed out. The second set included
 	// the first set of keys, but they were added before the first set timed
@@ -125,24 +134,29 @@ func TestDontHaveTimeoutMgrCancel(t *testing.T) {
 	latMultiplier := 1
 	expProcessTime := time.Duration(0)
 	expectedTimeout := latency
-	pc := &mockPeerConn{latency: latency}
+	clock := clock.NewMock()
+	pinged := make(chan struct{})
+	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged}
 	tr := timeoutRecorder{}
-
+	signal := make(chan struct{})
 	dhtm := newDontHaveTimeoutMgrWithParams(pc, tr.onTimeout,
-		dontHaveTimeout, maxTimeout, latMultiplier, messageLatencyMultiplier, expProcessTime)
+		dontHaveTimeout, maxTimeout, latMultiplier, messageLatencyMultiplier, expProcessTime, clock, signal)
 	dhtm.Start()
 	defer dhtm.Shutdown()
+	<-pinged
 
 	// Add keys
 	dhtm.AddPending(ks)
-	time.Sleep(5 * time.Millisecond)
+	clock.Add(5 * time.Millisecond)
 
 	// Cancel keys
 	cancelCount := 1
 	dhtm.CancelPending(ks[:cancelCount])
 
 	// Wait for the expected timeout
-	time.Sleep(expectedTimeout)
+	clock.Add(expectedTimeout)
+
+	<-signal
 
 	// At this stage all non-cancelled keys should have timed out
 	if tr.timedOutCount() != len(ks)-cancelCount {
@@ -156,30 +170,36 @@ func TestDontHaveTimeoutWantCancelWant(t *testing.T) {
 	latMultiplier := 1
 	expProcessTime := time.Duration(0)
 	expectedTimeout := latency
-	pc := &mockPeerConn{latency: latency}
+	clock := clock.NewMock()
+	pinged := make(chan struct{})
+	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged}
 	tr := timeoutRecorder{}
+	signal := make(chan struct{})
 
 	dhtm := newDontHaveTimeoutMgrWithParams(pc, tr.onTimeout,
-		dontHaveTimeout, maxTimeout, latMultiplier, messageLatencyMultiplier, expProcessTime)
+		dontHaveTimeout, maxTimeout, latMultiplier, messageLatencyMultiplier, expProcessTime, clock, signal)
 	dhtm.Start()
 	defer dhtm.Shutdown()
+	<-pinged
 
 	// Add keys
 	dhtm.AddPending(ks)
 
 	// Wait for a short time
-	time.Sleep(expectedTimeout - 10*time.Millisecond)
+	clock.Add(expectedTimeout - 10*time.Millisecond)
 
 	// Cancel two keys
 	dhtm.CancelPending(ks[:2])
 
-	time.Sleep(5 * time.Millisecond)
+	clock.Add(5 * time.Millisecond)
 
 	// Add back one cancelled key
 	dhtm.AddPending(ks[:1])
 
 	// Wait till after initial timeout
-	time.Sleep(10 * time.Millisecond)
+	clock.Add(10 * time.Millisecond)
+
+	<-signal
 
 	// At this stage only the key that was never cancelled should have timed out
 	if tr.timedOutCount() != 1 {
@@ -187,7 +207,9 @@ func TestDontHaveTimeoutWantCancelWant(t *testing.T) {
 	}
 
 	// Wait till after added back key should time out
-	time.Sleep(latency)
+	clock.Add(latency)
+
+	<-signal
 
 	// At this stage the key that was added back should also have timed out
 	if tr.timedOutCount() != 2 {
@@ -200,13 +222,17 @@ func TestDontHaveTimeoutRepeatedAddPending(t *testing.T) {
 	latency := time.Millisecond * 5
 	latMultiplier := 1
 	expProcessTime := time.Duration(0)
-	pc := &mockPeerConn{latency: latency}
+	clock := clock.NewMock()
+	pinged := make(chan struct{})
+	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged}
 	tr := timeoutRecorder{}
+	signal := make(chan struct{})
 
 	dhtm := newDontHaveTimeoutMgrWithParams(pc, tr.onTimeout,
-		dontHaveTimeout, maxTimeout, latMultiplier, messageLatencyMultiplier, expProcessTime)
+		dontHaveTimeout, maxTimeout, latMultiplier, messageLatencyMultiplier, expProcessTime, clock, signal)
 	dhtm.Start()
 	defer dhtm.Shutdown()
+	<-pinged
 
 	// Add keys repeatedly
 	for _, c := range ks {
@@ -214,7 +240,9 @@ func TestDontHaveTimeoutRepeatedAddPending(t *testing.T) {
 	}
 
 	// Wait for the expected timeout
-	time.Sleep(latency + 5*time.Millisecond)
+	clock.Add(latency + 5*time.Millisecond)
+
+	<-signal
 
 	// At this stage all keys should have timed out
 	if tr.timedOutCount() != len(ks) {
@@ -228,14 +256,17 @@ func TestDontHaveTimeoutMgrMessageLatency(t *testing.T) {
 	latMultiplier := 1
 	expProcessTime := time.Duration(0)
 	msgLatencyMultiplier := 1
-	pc := &mockPeerConn{latency: latency}
+	clock := clock.NewMock()
+	pinged := make(chan struct{})
+	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged}
 	tr := timeoutRecorder{}
+	signal := make(chan struct{})
 
 	dhtm := newDontHaveTimeoutMgrWithParams(pc, tr.onTimeout,
-		dontHaveTimeout, maxTimeout, latMultiplier, msgLatencyMultiplier, expProcessTime)
+		dontHaveTimeout, maxTimeout, latMultiplier, msgLatencyMultiplier, expProcessTime, clock, signal)
 	dhtm.Start()
 	defer dhtm.Shutdown()
-
+	<-pinged
 	// Add keys
 	dhtm.AddPending(ks)
 
@@ -245,7 +276,7 @@ func TestDontHaveTimeoutMgrMessageLatency(t *testing.T) {
 	// = 40ms
 
 	// Wait for less than the expected timeout
-	time.Sleep(25 * time.Millisecond)
+	clock.Add(25 * time.Millisecond)
 
 	// Receive two message latency updates
 	dhtm.UpdateMessageLatency(time.Millisecond * 20)
@@ -259,7 +290,9 @@ func TestDontHaveTimeoutMgrMessageLatency(t *testing.T) {
 	// the keys should have timed out
 
 	// Give the queue some time to process the updates
-	time.Sleep(5 * time.Millisecond)
+	clock.Add(5 * time.Millisecond)
+
+	<-signal
 
 	if tr.timedOutCount() != len(ks) {
 		t.Fatal("expected keys to timeout")
@@ -268,16 +301,19 @@ func TestDontHaveTimeoutMgrMessageLatency(t *testing.T) {
 
 func TestDontHaveTimeoutMgrMessageLatencyMax(t *testing.T) {
 	ks := testutil.GenerateCids(2)
-	pc := &mockPeerConn{latency: time.Second} // ignored
+	clock := clock.NewMock()
+	pinged := make(chan struct{})
+	pc := &mockPeerConn{latency: time.Second, clock: clock, pinged: pinged}
 	tr := timeoutRecorder{}
 	msgLatencyMultiplier := 1
 	testMaxTimeout := time.Millisecond * 10
+	signal := make(chan struct{})
 
 	dhtm := newDontHaveTimeoutMgrWithParams(pc, tr.onTimeout,
-		dontHaveTimeout, testMaxTimeout, pingLatencyMultiplier, msgLatencyMultiplier, maxExpectedWantProcessTime)
+		dontHaveTimeout, testMaxTimeout, pingLatencyMultiplier, msgLatencyMultiplier, maxExpectedWantProcessTime, clock, signal)
 	dhtm.Start()
 	defer dhtm.Shutdown()
-
+	<-pinged
 	// Add keys
 	dhtm.AddPending(ks)
 
@@ -286,7 +322,9 @@ func TestDontHaveTimeoutMgrMessageLatencyMax(t *testing.T) {
 	dhtm.UpdateMessageLatency(testMaxTimeout * 4)
 
 	// Sleep until just after the maximum timeout
-	time.Sleep(testMaxTimeout + 5*time.Millisecond)
+	clock.Add(testMaxTimeout + 5*time.Millisecond)
+
+	<-signal
 
 	// Keys should have timed out
 	if tr.timedOutCount() != len(ks) {
@@ -302,18 +340,22 @@ func TestDontHaveTimeoutMgrUsesDefaultTimeoutIfPingError(t *testing.T) {
 	defaultTimeout := 10 * time.Millisecond
 	expectedTimeout := expProcessTime + defaultTimeout
 	tr := timeoutRecorder{}
-	pc := &mockPeerConn{latency: latency, err: fmt.Errorf("ping error")}
+	clock := clock.NewMock()
+	pinged := make(chan struct{})
+	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged, err: fmt.Errorf("ping error")}
+	signal := make(chan struct{})
 
 	dhtm := newDontHaveTimeoutMgrWithParams(pc, tr.onTimeout,
-		defaultTimeout, dontHaveTimeout, latMultiplier, messageLatencyMultiplier, expProcessTime)
+		defaultTimeout, dontHaveTimeout, latMultiplier, messageLatencyMultiplier, expProcessTime, clock, signal)
 	dhtm.Start()
 	defer dhtm.Shutdown()
+	<-pinged
 
 	// Add keys
 	dhtm.AddPending(ks)
 
 	// Sleep for less than the expected timeout
-	time.Sleep(expectedTimeout - 5*time.Millisecond)
+	clock.Add(expectedTimeout - 5*time.Millisecond)
 
 	// At this stage no timeout should have happened yet
 	if tr.timedOutCount() > 0 {
@@ -321,7 +363,9 @@ func TestDontHaveTimeoutMgrUsesDefaultTimeoutIfPingError(t *testing.T) {
 	}
 
 	// Sleep until after the expected timeout
-	time.Sleep(10 * time.Millisecond)
+	clock.Add(10 * time.Millisecond)
+
+	<-signal
 
 	// Now the keys should have timed out
 	if tr.timedOutCount() != len(ks) {
@@ -335,19 +379,23 @@ func TestDontHaveTimeoutMgrUsesDefaultTimeoutIfLatencyLonger(t *testing.T) {
 	latMultiplier := 1
 	expProcessTime := time.Duration(0)
 	defaultTimeout := 10 * time.Millisecond
+	clock := clock.NewMock()
+	pinged := make(chan struct{})
+	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged}
 	tr := timeoutRecorder{}
-	pc := &mockPeerConn{latency: latency}
+	signal := make(chan struct{})
 
 	dhtm := newDontHaveTimeoutMgrWithParams(pc, tr.onTimeout,
-		defaultTimeout, dontHaveTimeout, latMultiplier, messageLatencyMultiplier, expProcessTime)
+		defaultTimeout, dontHaveTimeout, latMultiplier, messageLatencyMultiplier, expProcessTime, clock, signal)
 	dhtm.Start()
 	defer dhtm.Shutdown()
+	<-pinged
 
 	// Add keys
 	dhtm.AddPending(ks)
 
 	// Sleep for less than the default timeout
-	time.Sleep(defaultTimeout - 5*time.Millisecond)
+	clock.Add(defaultTimeout - 5*time.Millisecond)
 
 	// At this stage no timeout should have happened yet
 	if tr.timedOutCount() > 0 {
@@ -355,7 +403,9 @@ func TestDontHaveTimeoutMgrUsesDefaultTimeoutIfLatencyLonger(t *testing.T) {
 	}
 
 	// Sleep until after the default timeout
-	time.Sleep(defaultTimeout * 2)
+	clock.Add(defaultTimeout * 2)
+
+	<-signal
 
 	// Now the keys should have timed out
 	if tr.timedOutCount() != len(ks) {
@@ -368,25 +418,29 @@ func TestDontHaveTimeoutNoTimeoutAfterShutdown(t *testing.T) {
 	latency := time.Millisecond * 10
 	latMultiplier := 1
 	expProcessTime := time.Duration(0)
+	clock := clock.NewMock()
+	pinged := make(chan struct{})
+	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged}
 	tr := timeoutRecorder{}
-	pc := &mockPeerConn{latency: latency}
+	signal := make(chan struct{})
 
 	dhtm := newDontHaveTimeoutMgrWithParams(pc, tr.onTimeout,
-		dontHaveTimeout, maxTimeout, latMultiplier, messageLatencyMultiplier, expProcessTime)
+		dontHaveTimeout, maxTimeout, latMultiplier, messageLatencyMultiplier, expProcessTime, clock, signal)
 	dhtm.Start()
 	defer dhtm.Shutdown()
+	<-pinged
 
 	// Add keys
 	dhtm.AddPending(ks)
 
 	// Wait less than the timeout
-	time.Sleep(latency - 5*time.Millisecond)
+	clock.Add(latency - 5*time.Millisecond)
 
 	// Shutdown the manager
 	dhtm.Shutdown()
 
 	// Wait for the expected timeout
-	time.Sleep(10 * time.Millisecond)
+	clock.Add(10 * time.Millisecond)
 
 	// Manager was shut down so timeout should not have fired
 	if tr.timedOutCount() != 0 {

--- a/network/ipfs_impl.go
+++ b/network/ipfs_impl.go
@@ -403,8 +403,8 @@ func (bsnet *impl) handleNewStream(s network.Stream) {
 		ctx := context.Background()
 		log.Debugf("bitswap net handleNewStream from %s", s.Conn().RemotePeer())
 		bsnet.connectEvtMgr.OnMessage(s.Conn().RemotePeer())
-		bsnet.receiver.ReceiveMessage(ctx, p, received)
 		atomic.AddUint64(&bsnet.stats.MessagesRecvd, 1)
+		bsnet.receiver.ReceiveMessage(ctx, p, received)
 	}
 }
 


### PR DESCRIPTION
# Goals

Fix flaky tests for the DontHaveTimeoutManger

# Implementation

Replace clock with a mock, so that we are able to mock out time in tests, modify tests to use mock time and be more predictable.

Also avoid AfterFunc cause of potential problems with channel consumption.