### PR TITLE
Fix flaky TestNetworkCounters tests

### DIFF
--- a/network/ipfs_impl.go
+++ b/network/ipfs_impl.go
@@ -403,8 +403,8 @@ func (bsnet *impl) handleNewStream(s network.Stream) {
 		ctx := context.Background()
 		log.Debugf("bitswap net handleNewStream from %s", s.Conn().RemotePeer())
 		bsnet.connectEvtMgr.OnMessage(s.Conn().RemotePeer())
-		bsnet.receiver.ReceiveMessage(ctx, p, received)
 		atomic.AddUint64(&bsnet.stats.MessagesRecvd, 1)
+		bsnet.receiver.ReceiveMessage(ctx, p, received)
 	}
 }
 


### PR DESCRIPTION
# Goals

Fix TestNetworkCounters flakiness
part of fixing #493 

# Implemenation

The problem is just a race in counting messages, and I've dealt with that by moving the counting to immediately before the call that advances the test. I don't think it's relevant to Bitswap execution otherwise.