### PR TITLE
fix: hold the task worker lock when starting task workers

### DIFF
--- a/internal/decision/engine.go
+++ b/internal/decision/engine.go
@@ -235,6 +235,9 @@ func (e *Engine) StartWorkers(ctx context.Context, px process.Process) {
 	e.bsm.start(px)
 	e.startScoreLedger(px)
 
+	e.taskWorkerLock.Lock()
+	defer e.taskWorkerLock.Unlock()
+
 	for i := 0; i < e.taskWorkerCount; i++ {
 		px.Go(func(px process.Process) {
 			e.taskWorker(ctx)


### PR DESCRIPTION
Otherwise, we could try to shutdown at the same time and race.