### PR TITLE
fix(decision): fix a datarace on disconnect

### DIFF
--- a/internal/decision/engine.go
+++ b/internal/decision/engine.go
@@ -703,7 +703,11 @@ func (e *Engine) PeerDisconnected(p peer.ID) {
 
 	ledger, ok := e.ledgerMap[p]
 	if ok {
-		for _, entry := range ledger.Entries() {
+		ledger.lk.RLock()
+		entries := ledger.Entries()
+		ledger.lk.RUnlock()
+
+		for _, entry := range entries {
 			e.peerLedger.CancelWant(p, entry.Cid)
 		}
 	}


### PR DESCRIPTION
We need to hold the ledger's lock while reading from it.