### PR TITLE
feat: add peer block filter option

### DIFF
--- a/bitswap.go
+++ b/bitswap.go
@@ -154,8 +154,15 @@ func WithTargetMessageSize(tms int) Option {
 	}
 }
 
+func WithPeerBlockRequestFilter(pbrf PeerBlockRequestFilter) Option {
+	return func(bs *Bitswap) {
+		bs.peerBlockRequestFilter = pbrf
+	}
+}
+
 type TaskInfo = decision.TaskInfo
 type TaskComparator = decision.TaskComparator
+type PeerBlockRequestFilter = decision.PeerBlockRequestFilter
 
 // WithTaskComparator configures custom task prioritization logic.
 func WithTaskComparator(comparator TaskComparator) Option {
@@ -291,6 +298,7 @@ func New(parent context.Context, network bsnet.BitSwapNetwork,
 		activeBlocksGauge,
 		decision.WithTaskComparator(bs.taskComparator),
 		decision.WithTargetMessageSize(bs.engineTargetMessageSize),
+		decision.WithPeerBlockRequestFilter(bs.peerBlockRequestFilter),
 	)
 	bs.engine.SetSendDontHaves(bs.engineSetSendDontHaves)
 
@@ -399,6 +407,9 @@ type Bitswap struct {
 	simulateDontHavesOnTimeout bool
 
 	taskComparator TaskComparator
+
+	// an optional feature to accept / deny requests for blocks
+	peerBlockRequestFilter PeerBlockRequestFilter
 }
 
 type counters struct {

--- a/internal/decision/engine_test.go
+++ b/internal/decision/engine_test.go
@@ -1118,22 +1118,19 @@ func TestPeerBlockFilter(t *testing.T) {
 
 	// Generate a few keys
 	keys := []string{"a", "b", "c"}
-	cids := make(map[cid.Cid]int)
 	blks := make([]blocks.Block, 0, len(keys))
-	for i, letter := range keys {
+	for _, letter := range keys {
 		block := blocks.NewBlock([]byte(letter))
 		blks = append(blks, block)
-		cids[block.Cid()] = i
 	}
 
-	// Generate a few peers
-	peerIDs := make([]peer.ID, len(keys))
-	for _, i := range cids {
-		peerID := libp2ptest.RandPeerIDFatal(t)
-		peerIDs[i] = peerID
-	}
+	// Generate a few partner peers
+	peerIDs := make([]peer.ID, 3)
+	peerIDs[0] = libp2ptest.RandPeerIDFatal(t)
+	peerIDs[1] = libp2ptest.RandPeerIDFatal(t)
+	peerIDs[2] = libp2ptest.RandPeerIDFatal(t)
 
-	// Setup the peer
+	// Setup the main peer
 	fpt := &fakePeerTagger{}
 	sl := NewTestScoreLedger(shortTerm, nil, clock.New())
 	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))

--- a/internal/decision/engine_test.go
+++ b/internal/decision/engine_test.go
@@ -1138,9 +1138,7 @@ func TestPeerBlockFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// use a single task worker so that the order of outgoing messages is deterministic
-	engineTaskWorkerCount := 1
-	e := newEngineForTesting(ctx, bs, 4, engineTaskWorkerCount, defaults.BitswapMaxOutstandingBytesPerPeer, fpt, "localhost", 0, sl,
+	e := newEngineForTesting(ctx, bs, 4, defaults.BitswapEngineTaskWorkerCount, defaults.BitswapMaxOutstandingBytesPerPeer, fpt, "localhost", 0, sl,
 		WithPeerBlockRequestFilter(func(p peer.ID, c cid.Cid) bool {
 			// peer 0 has access to everything
 			if p == peerIDs[0] {
@@ -1297,9 +1295,7 @@ func TestPeerBlockFilterMutability(t *testing.T) {
 
 	filterAllowList := make(map[cid.Cid]bool)
 
-	// use a single task worker so that the order of outgoing messages is deterministic
-	engineTaskWorkerCount := 1
-	e := newEngineForTesting(ctx, bs, 4, engineTaskWorkerCount, defaults.BitswapMaxOutstandingBytesPerPeer, fpt, "localhost", 0, sl,
+	e := newEngineForTesting(ctx, bs, 4, defaults.BitswapEngineTaskWorkerCount, defaults.BitswapMaxOutstandingBytesPerPeer, fpt, "localhost", 0, sl,
 		WithPeerBlockRequestFilter(func(p peer.ID, c cid.Cid) bool {
 			return filterAllowList[c]
 		}),

--- a/internal/decision/engine_test.go
+++ b/internal/decision/engine_test.go
@@ -1158,10 +1158,9 @@ func TestPeerBlockFilter(t *testing.T) {
 
 	// Setup the test
 	type testCaseEntry struct {
-		peerIndex    int
-		wantBlks     string
-		wantHaves    string
-		sendDontHave bool
+		peerIndex int
+		wantBlks  string
+		wantHaves string
 	}
 
 	type testCaseExp struct {
@@ -1180,9 +1179,8 @@ func TestPeerBlockFilter(t *testing.T) {
 		// Peer 0 has access to everything: want-block `a` succeeds.
 		{
 			wl: testCaseEntry{
-				peerIndex:    0,
-				wantBlks:     "a",
-				sendDontHave: true,
+				peerIndex: 0,
+				wantBlks:  "a",
 			},
 			exp: testCaseExp{
 				blks: "a",
@@ -1191,9 +1189,8 @@ func TestPeerBlockFilter(t *testing.T) {
 		// Peer 0 has access to everything: want-have `b` succeeds.
 		{
 			wl: testCaseEntry{
-				peerIndex:    0,
-				wantHaves:    "b1",
-				sendDontHave: true,
+				peerIndex: 0,
+				wantHaves: "b1",
 			},
 			exp: testCaseExp{
 				haves:     "b",
@@ -1203,9 +1200,8 @@ func TestPeerBlockFilter(t *testing.T) {
 		// Peer 1 has access to [c, d]: want-have `a` result in dont-have.
 		{
 			wl: testCaseEntry{
-				peerIndex:    1,
-				wantHaves:    "ac",
-				sendDontHave: true,
+				peerIndex: 1,
+				wantHaves: "ac",
 			},
 			exp: testCaseExp{
 				haves:     "c",
@@ -1215,9 +1211,8 @@ func TestPeerBlockFilter(t *testing.T) {
 		// Peer 1 has access to [c, d]: want-block `b` result in dont-have.
 		{
 			wl: testCaseEntry{
-				peerIndex:    1,
-				wantBlks:     "bd",
-				sendDontHave: true,
+				peerIndex: 1,
+				wantBlks:  "bd",
 			},
 			exp: testCaseExp{
 				blks:      "d",
@@ -1227,10 +1222,9 @@ func TestPeerBlockFilter(t *testing.T) {
 		// Peer 2 has access to [d]: want-have `a` and want-block `b` result in dont-have.
 		{
 			wl: testCaseEntry{
-				peerIndex:    2,
-				wantHaves:    "a",
-				wantBlks:     "bcd1",
-				sendDontHave: true,
+				peerIndex: 2,
+				wantHaves: "a",
+				wantBlks:  "bcd1",
 			},
 			exp: testCaseExp{
 				haves:     "",
@@ -1254,13 +1248,13 @@ func TestPeerBlockFilter(t *testing.T) {
 		// Create wants requests
 		wl := testCase.wl
 
-		t.Logf("test case %v: Peer%v / want-blocks '%s' / want-haves '%s' / sendDontHave %t",
-			i, wl.peerIndex, wl.wantBlks, wl.wantHaves, wl.sendDontHave)
+		t.Logf("test case %v: Peer%v / want-blocks '%s' / want-haves '%s'",
+			i, wl.peerIndex, wl.wantBlks, wl.wantHaves)
 
 		wantBlks := strings.Split(wl.wantBlks, "")
 		wantHaves := strings.Split(wl.wantHaves, "")
 
-		partnerWantBlocksHaves(e, wantBlks, wantHaves, wl.sendDontHave, peerIDs[wl.peerIndex])
+		partnerWantBlocksHaves(e, wantBlks, wantHaves, true, peerIDs[wl.peerIndex])
 
 		// Check result
 		exp := testCase.exp
@@ -1314,10 +1308,9 @@ func TestPeerBlockFilterMutability(t *testing.T) {
 
 	// Setup the test
 	type testCaseEntry struct {
-		allowList    string
-		wantBlks     string
-		wantHaves    string
-		sendDontHave bool
+		allowList string
+		wantBlks  string
+		wantHaves string
 	}
 
 	type testCaseExp struct {
@@ -1337,15 +1330,13 @@ func TestPeerBlockFilterMutability(t *testing.T) {
 			wls: []testCaseEntry{
 				{
 					// Peer has no accesses & request a want-block
-					allowList:    "",
-					wantBlks:     "a",
-					sendDontHave: true,
+					allowList: "",
+					wantBlks:  "a",
 				},
 				{
 					// Then Peer is allowed access to a
-					allowList:    "a",
-					wantBlks:     "a",
-					sendDontHave: true,
+					allowList: "a",
+					wantBlks:  "a",
 				},
 			},
 			exps: []testCaseExp{
@@ -1361,15 +1352,13 @@ func TestPeerBlockFilterMutability(t *testing.T) {
 			wls: []testCaseEntry{
 				{
 					// Peer has access to bc
-					allowList:    "bc",
-					wantHaves:    "bc",
-					sendDontHave: true,
+					allowList: "bc",
+					wantHaves: "bc",
 				},
 				{
 					// Then Peer loses access to b
-					allowList:    "c",
-					wantBlks:     "bc", // Note: We request a block here to force a response from the node
-					sendDontHave: true,
+					allowList: "c",
+					wantBlks:  "bc", // Note: We request a block here to force a response from the node
 				},
 			},
 			exps: []testCaseExp{
@@ -1422,8 +1411,8 @@ func TestPeerBlockFilterMutability(t *testing.T) {
 			exp := testCase.exps[j]
 
 			// Create wants requests
-			t.Logf("test case %v, %v: allow-list '%s' / want-blocks '%s' / want-haves '%s' / sendDontHave %t",
-				i, j, wl.allowList, wl.wantBlks, wl.wantHaves, wl.sendDontHave)
+			t.Logf("test case %v, %v: allow-list '%s' / want-blocks '%s' / want-haves '%s'",
+				i, j, wl.allowList, wl.wantBlks, wl.wantHaves)
 
 			allowList := strings.Split(wl.allowList, "")
 			wantBlks := strings.Split(wl.wantBlks, "")
@@ -1437,7 +1426,7 @@ func TestPeerBlockFilterMutability(t *testing.T) {
 			}
 
 			// Send the request
-			partnerWantBlocksHaves(e, wantBlks, wantHaves, wl.sendDontHave, partnerID)
+			partnerWantBlocksHaves(e, wantBlks, wantHaves, true, partnerID)
 
 			// Check result
 			next := <-e.Outbox()

--- a/internal/decision/engine_test.go
+++ b/internal/decision/engine_test.go
@@ -1284,24 +1284,24 @@ func TestTaggingUseful(t *testing.T) {
 	}
 }
 
-func partnerWantBlocks(e *Engine, keys []string, partner peer.ID) {
+func partnerWantBlocks(e *Engine, wantBlocks []string, partner peer.ID) {
 	add := message.New(false)
-	for i, letter := range keys {
+	for i, letter := range wantBlocks {
 		block := blocks.NewBlock([]byte(letter))
-		add.AddEntry(block.Cid(), int32(len(keys)-i), pb.Message_Wantlist_Block, true)
+		add.AddEntry(block.Cid(), int32(len(wantBlocks)-i), pb.Message_Wantlist_Block, true)
 	}
 	e.MessageReceived(context.Background(), partner, add)
 }
 
-func partnerWantBlocksHaves(e *Engine, keys []string, wantHaves []string, sendDontHave bool, partner peer.ID) {
+func partnerWantBlocksHaves(e *Engine, wantBlocks []string, wantHaves []string, sendDontHave bool, partner peer.ID) {
 	add := message.New(false)
-	priority := int32(len(wantHaves) + len(keys))
+	priority := int32(len(wantHaves) + len(wantBlocks))
 	for _, letter := range wantHaves {
 		block := blocks.NewBlock([]byte(letter))
 		add.AddEntry(block.Cid(), priority, pb.Message_Wantlist_Have, sendDontHave)
 		priority--
 	}
-	for _, letter := range keys {
+	for _, letter := range wantBlocks {
 		block := blocks.NewBlock([]byte(letter))
 		add.AddEntry(block.Cid(), priority, pb.Message_Wantlist_Block, sendDontHave)
 		priority--


### PR DESCRIPTION
This feature lets a user configure a filter to allow / deny request according to the request's peer ID and the content id.

For example, a user may use this option to implement a dynamic peer-based authorization.