### PR TITLE
fix: shard lock to fix contention issue in the notify handler

### DIFF
--- a/internal/decision/engine.go
+++ b/internal/decision/engine.go
@@ -914,12 +914,13 @@ func (e *Engine) MessageSent(p peer.ID, m bsmsg.BitSwapMessage) {
 // sending blocks.
 func (e *Engine) PeerConnected(p peer.ID) {
 	e.lock.Lock()
-	defer e.lock.Unlock()
 
 	_, ok := e.ledgerMap[p]
 	if !ok {
 		e.ledgerMap[p] = newLedger(p)
 	}
+
+	e.lock.Unlock()
 
 	e.scoreLedger.PeerConnected(p)
 }
@@ -927,7 +928,6 @@ func (e *Engine) PeerConnected(p peer.ID) {
 // PeerDisconnected is called when a peer disconnects.
 func (e *Engine) PeerDisconnected(p peer.ID) {
 	e.lock.Lock()
-	defer e.lock.Unlock()
 
 	ledger, ok := e.ledgerMap[p]
 	if ok {
@@ -940,6 +940,8 @@ func (e *Engine) PeerDisconnected(p peer.ID) {
 		}
 	}
 	delete(e.ledgerMap, p)
+
+	e.lock.Unlock()
 
 	e.scoreLedger.PeerDisconnected(p)
 }


### PR DESCRIPTION
I have many profiles where I had 5k+ goroutines all waiting on connectEventManager.lk while downloading.
![Capture d’écran du 2022-04-06 04-07-49](https://user-images.githubusercontent.com/24391983/161883038-3202fc6d-ea6f-4212-b3d7-762965445b29.png)

Turns out it defer the unlock call, and call to an other function, however all of the other sub handlers all have their own locking mechanism.
So I've made it unlock first then call to the next function. (this breaks order as maybe a handler had side effect that relied on peers being handled in the same order as an other one but AFAIK this isn't a thing, all the sub handlers are fairly sane doesn't have such side effect).

I've done the same fix in engine because why not ? (as the exact same argument of consumers locking too can be made) and this completely removed it from the profile.

This patch completely removes those functions from the profile for me.