### PR TITLE
[WIP] Experiment: Option for dynamically manageable requests

### DIFF
--- a/client/sessioniface/fetcher.go
+++ b/client/sessioniface/fetcher.go
@@ -1,0 +1,18 @@
+package sessioniface
+
+import (
+	"context"
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	exchange "github.com/ipfs/go-ipfs-exchange-interface"
+)
+
+type AddRemoveCid interface {
+	IsAdd() bool
+	Key() cid.Cid
+}
+
+type ChannelFetcher interface {
+	exchange.Fetcher
+	GetBlocksCh(ctx context.Context, keys <-chan AddRemoveCid) (<-chan blocks.Block, error)
+}


### PR DESCRIPTION
Related to one of the suggestions in https://github.com/ipfs/go-libipfs/issues/90, this provides an option to request blocks from a session using a channel instead of requesting blocks as groups of CIDs.

This means that users of a session can dynamically discover and request as many blocks as it wants without needing to spin up many goroutines to wait on the blocks or artificially group the block requests together.

This was useful to me as part of implementing https://github.com/aschmahmann/mdinc/pull/1. 

Note: This initial approach is definitely not as polished as it could be and we can clean up the names and the plumbing here a bunch. However, it worked for the Docker [demo](https://bafybeifhfiynbz36lbho2pow6h3w5hxj2orimr6zcjjxkzdj2vw5ekk62y.ipfs.w3s.link/docker-ipfs-demo.mkv) and gave a starting point for a conversation on if this is a good idea and collecting feedback on the feature.

Some areas for feedback:
1. Any reason we shouldn't do this?
2. Should the new function take a channel or some object that has `Add(cid)` and `Remove(cid)` called on it? Passing channels is more natural to Go and makes sense for performance, but I've noticed can sometimes confuse people. Went with channels since it seemed like less code and also happened to match the issue linked above.
3. Should the new function take an interface or a struct? I went with an interface here so I didn't have to change public exports,  but IMO if we're exposing new functionality to the user it'd be nice to give them an interface to match against if they want to and in that case a struct is fair game too
4. Naming suggestions? People tend to drop those anyway so figure I'd call it out explicitly 😄 