### PR TITLE
Add hooks for better peer filters

### DIFF
--- a/server/internal/decision/engine_test.go
+++ b/server/internal/decision/engine_test.go
@@ -1040,6 +1040,22 @@ func TestWantlistForPeer(t *testing.T) {
 		t.Fatal("expected wantlist to be sorted")
 	}
 
+	if e.WantCountForPeer(partner) != 4 {
+		t.Fatal("expected wantlist count to be accurate")
+	}
+
+	if e.TotalWants() != 4 {
+		t.Fatal("expected total wants count to be accurate")
+	}
+
+	msg3 := message.New(false)
+	msg3.AddEntry(blks[0].Cid(), 2, pb.Message_Wantlist_Have, false)
+	msg3.AddEntry(blks[1].Cid(), 3, pb.Message_Wantlist_Have, false)
+	e.MessageReceived(context.Background(), otherPeer, msg3)
+
+	if e.TotalWants() != 6 {
+		t.Fatal("expected total wants count to be accurate across peers")
+	}
 }
 
 func TestTaskComparator(t *testing.T) {


### PR DESCRIPTION
# Goals

There's a long standing request to support limits in the server like bandwidth, simultaneous wants (total and per peer). 

Without wanting to make big changes here to support this, for the time being this PR just exposes a couple additional configs and utility functions on the server implementation that would allow someone running a peer block filter to implement such limits. You can see how we use this in boost here: https://github.com/filecoin-project/boost/pull/1020

# Implementation

- Expose two more optimized functions for counting in progress wants (TotalWants() & WantCountForPeer()) to the Server
   - technically you could use the list of peers from Stats() + WantListPerPeer() to accomplish the same goal. However, these involve a LOT of memory copying around -- particularly cause you're making many copies of want list. This seemed worth optimizing for better performance
- Add a listener for when data actually goes over the wire.